### PR TITLE
Fix showSaleDialog load performance

### DIFF
--- a/ProductSale.gs
+++ b/ProductSale.gs
@@ -7,7 +7,8 @@ function onOpen() {
 
 function showSaleDialog() {
   var tpl = HtmlService.createTemplateFromFile('sale');
-  tpl.snList = getInventorySNList();
+  // Load SN list asynchronously on the client to speed up dialog opening
+  tpl.snList = [];
   var html = tpl.evaluate()
     .setWidth(1200)
     .setHeight(800);

--- a/sale.html
+++ b/sale.html
@@ -71,11 +71,7 @@
     </style>
   </head>
   <body>
-    <datalist id="snList">
-      <? snList.forEach(function(sn){ ?>
-        <option value="<?= sn ?>"></option>
-      <? }); ?>
-    </datalist>
+    <datalist id="snList"></datalist>
     <div id="products"></div>
     <div id="totalDiv">
       جمع کل: <span id="total">0</span> تومان
@@ -180,6 +176,14 @@
         finalInput.dataset.val = 0;
         finalInput.addEventListener('focus', function(){ this.value = this.dataset.val; });
         finalInput.addEventListener('blur', function(){ this.dataset.val = parseNumber(this.value); this.value = formatNumber(this.dataset.val); });
+        google.script.run.withSuccessHandler(function(list){
+          var dl = document.getElementById('snList');
+          list.forEach(function(sn){
+            var opt = document.createElement('option');
+            opt.value = sn;
+            dl.appendChild(opt);
+          });
+        }).getInventorySNList();
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary
- avoid loading the SN list on server side when opening the sale dialog
- fetch the SN list asynchronously in the HTML UI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688912850b38832cb8a2304883b6eeb0