### PR TITLE
Fix Enter key handling when searching products

### DIFF
--- a/sale.html
+++ b/sale.html
@@ -131,6 +131,10 @@
         input.addEventListener('keydown', function(e) {
           if (e.key === 'Enter') {
             e.preventDefault();
+          }
+        });
+        input.addEventListener('keyup', function(e) {
+          if (e.key === 'Enter') {
             searchProduct(input);
           }
         });


### PR DESCRIPTION
## Summary
- handle Enter with `keyup` so datalist selections are applied before searching

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688924541fd0832cae452a0e2e294e3e