### PR TITLE
Fix Farsi number parsing in product lookup

### DIFF
--- a/ProductSale.gs
+++ b/ProductSale.gs
@@ -28,8 +28,12 @@ function getInventorySNList() {
 
 function toEnglishNumber_(str) {
   return String(str)
-    .replace(/[\u06F0-\u06F9]/g, function(d){return d.charCodeAt(0)-1728;})
-    .replace(/[\u0660-\u0669]/g, function(d){return d.charCodeAt(0)-1584;});
+    .replace(/[\u06F0-\u06F9]/g, function(d){
+      return String.fromCharCode(d.charCodeAt(0) - 1728);
+    })
+    .replace(/[\u0660-\u0669]/g, function(d){
+      return String.fromCharCode(d.charCodeAt(0) - 1584);
+    });
 }
 
 function searchInventory(sn) {

--- a/sale.html
+++ b/sale.html
@@ -104,8 +104,12 @@
     var container;
 
     function toEnglishNumber(str) {
-      return str.replace(/[\u06F0-\u06F9]/g, function(d){return d.charCodeAt(0)-1728;})
-                .replace(/[\u0660-\u0669]/g, function(d){return d.charCodeAt(0)-1584;});
+      return str.replace(/[\u06F0-\u06F9]/g, function(d){
+                    return String.fromCharCode(d.charCodeAt(0) - 1728);
+                })
+                .replace(/[\u0660-\u0669]/g, function(d){
+                    return String.fromCharCode(d.charCodeAt(0) - 1584);
+                });
     }
 
     function toFarsiNumber(str) {


### PR DESCRIPTION
## Summary
- fix digit conversion in server and client scripts

## Testing
- `node -e "function toEnglishNumber(str){return String(str).replace(/[\u06F0-\u06F9]/g,function(d){return String.fromCharCode(d.charCodeAt(0)-1728);}).replace(/[\u0660-\u0669]/g,function(d){return String.fromCharCode(d.charCodeAt(0)-1584);});} console.log(toEnglishNumber('۱۲۳۴'))"`

------
https://chatgpt.com/codex/tasks/task_e_68892734d3bc832c9e1274531f70c3c1