### PR TITLE
Fix Enter key search in sale dialog

### DIFF
--- a/sale.html
+++ b/sale.html
@@ -131,6 +131,10 @@
         input.addEventListener('keydown', function(e) {
           if (e.key === 'Enter') {
             e.preventDefault();
+          }
+        });
+        input.addEventListener('keyup', function(e) {
+          if (e.key === 'Enter') {
             searchProduct(input);
           }
         });


### PR DESCRIPTION
## Summary
- handle Enter on keyup so datalist selections trigger product search

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68892734d3bc832c9e1274531f70c3c1