### PR TITLE
Fix product search by trimming zero width spaces

### DIFF
--- a/ProductSale.gs
+++ b/ProductSale.gs
@@ -29,18 +29,19 @@ function getInventorySNList() {
 function toEnglishNumber_(str) {
   return String(str)
     .replace(/[\u06F0-\u06F9]/g, function(d){return d.charCodeAt(0)-1728;})
-    .replace(/[\u0660-\u0669]/g, function(d){return d.charCodeAt(0)-1584;});
+    .replace(/[\u0660-\u0669]/g, function(d){return d.charCodeAt(0)-1584;})
+    .replace(/[\u200c\u200b]/g, '');
 }
 
 function searchInventory(sn) {
   var ss = SpreadsheetApp.getActive();
   var snRange = ss.getRangeByName('InventorySN');
   if (!snRange) return null;
-  var snNorm = toEnglishNumber_(sn).replace(/\s+/g, '');
+  var snNorm = toEnglishNumber_(sn).replace(/[\s\u200c\u200b]+/g, '');
   var snNum = Number(snNorm);
   var values = snRange.getValues();
   for (var i = 0; i < values.length; i++) {
-    var cellVal = toEnglishNumber_(values[i][0]).replace(/\s+/g, '');
+    var cellVal = toEnglishNumber_(values[i][0]).replace(/[\s\u200c\u200b]+/g, '');
     var cellNum = Number(cellVal);
     if ((snNum && cellNum && snNum === cellNum) || cellVal === snNorm) {
       var row = snRange.getCell(i + 1, 1).getRow();

--- a/sale.html
+++ b/sale.html
@@ -104,8 +104,9 @@
     var container;
 
     function toEnglishNumber(str) {
-      return str.replace(/[\u06F0-\u06F9]/g, function(d){return d.charCodeAt(0)-1728;})
-                .replace(/[\u0660-\u0669]/g, function(d){return d.charCodeAt(0)-1584;});
+      return (str || '').replace(/[\u06F0-\u06F9]/g, function(d){return d.charCodeAt(0)-1728;})
+                .replace(/[\u0660-\u0669]/g, function(d){return d.charCodeAt(0)-1584;})
+                .replace(/[\u200c\u200b]/g, '');
     }
 
     function toFarsiNumber(str) {
@@ -142,7 +143,7 @@
       }
 
       function searchProduct(input) {
-        var sn = toEnglishNumber(input.value).trim();
+        var sn = toEnglishNumber(input.value).replace(/[\u200c\u200b]/g, '').trim();
         if (!sn) return;
         google.script.run.withSuccessHandler(function(res) {
           if (!res) {


### PR DESCRIPTION
## Summary
- strip zero width spaces when converting serial numbers to English digits
- normalize serial numbers on both server and client

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68892734d3bc832c9e1274531f70c3c1