### PR TITLE
Speed up barcode lookup by caching inventory client-side

### DIFF
--- a/ProductSale.gs
+++ b/ProductSale.gs
@@ -26,6 +26,35 @@ function getInventorySNList() {
   return values.slice(startIndex).map(function(r){ return r[0]; });
 }
 
+function getInventoryData() {
+  var ss = SpreadsheetApp.getActive();
+  var snRange = ss.getRangeByName('InventorySN');
+  if (!snRange) return [];
+  var sheet = snRange.getSheet();
+  var frozen = sheet.getFrozenRows();
+  var startIndex = Math.max(0, frozen - (snRange.getRow() - 1));
+
+  var nameRange = ss.getRangeByName('InventoryName');
+  var brandRange = ss.getRangeByName('InventoryBrand');
+  var priceRange = ss.getRangeByName('InventoryPrice');
+  var locationRange = ss.getRangeByName('InventoryLocation');
+
+  var snValues = snRange.getValues();
+  var data = [];
+  for (var i = startIndex; i < snValues.length; i++) {
+    var row = snRange.getRow() + i;
+    var sn = toEnglishNumber_(snValues[i][0]).replace(/\s+/g, '');
+    data.push({
+      sn: sn,
+      name: getCellValueByName('InventoryName', row),
+      brand: getCellValueByName('InventoryBrand', row),
+      price: getCellValueByName('InventoryPrice', row),
+      location: getCellValueByName('InventoryLocation', row)
+    });
+  }
+  return data;
+}
+
 function toEnglishNumber_(str) {
   return String(str)
     .replace(/[\u06F0-\u06F9]/g, function(d){return d.charCodeAt(0)-1728;})

--- a/sale.html
+++ b/sale.html
@@ -102,6 +102,7 @@
     <script>
     var products = [];
     var container;
+    var inventoryMap = {};
 
     function toEnglishNumber(str) {
       return str.replace(/[\u06F0-\u06F9]/g, function(d){return d.charCodeAt(0)-1728;})
@@ -142,31 +143,30 @@
       }
 
       function searchProduct(input) {
-        var sn = toEnglishNumber(input.value).trim();
+        var sn = toEnglishNumber(input.value).trim().replace(/\s+/g, '');
         if (!sn) return;
-        google.script.run.withSuccessHandler(function(res) {
-          if (!res) {
-            alert('یافت نشد');
-            return;
-          }
-          var div = document.createElement('div');
-          div.className = 'product';
-          var locationText = (res.location === 'STORE') ? 'مغازه' : (res.location || '-');
-          var priceVal = parseNumber(res.price);
-          div.innerHTML = '<span class="label">نام محصول:</span><span>' + (res.name || '-') + '</span>'+
-            '<br><span class="label">برند:</span><span>' + (res.brand || '-') + '</span>'+
-            '<br><span class="label">قیمت:</span><input type="text" class="priceInput" value="' + formatNumber(priceVal) + '" data-val="' + priceVal + '"> تومان'+
-            '<br><span class="label">موقعیت:</span><span>' + locationText + '</span>';
-          container.insertBefore(div, input.nextSibling);
-          var priceInput = div.querySelector('.priceInput');
-          priceInput.addEventListener('focus', function(){ this.value = this.dataset.val; });
-          priceInput.addEventListener('blur', function(){ this.dataset.val = parseNumber(this.value); this.value = formatNumber(this.dataset.val); updateTotal(); });
-          priceInput.addEventListener('input', function(){ this.dataset.val = parseNumber(this.value); });
-          products.push({priceInput: priceInput});
-          updateTotal();
-          input.value = '';
-          input.focus();
-        }).searchInventory(sn);
+        var res = inventoryMap[sn];
+        if (!res) {
+          alert('یافت نشد');
+          return;
+        }
+        var div = document.createElement('div');
+        div.className = 'product';
+        var locationText = (res.location === 'STORE') ? 'مغازه' : (res.location || '-');
+        var priceVal = parseNumber(res.price);
+        div.innerHTML = '<span class="label">نام محصول:</span><span>' + (res.name || '-') + '</span>'+
+          '<br><span class="label">برند:</span><span>' + (res.brand || '-') + '</span>'+
+          '<br><span class="label">قیمت:</span><input type="text" class="priceInput" value="' + formatNumber(priceVal) + '" data-val="' + priceVal + '"> تومان'+
+          '<br><span class="label">موقعیت:</span><span>' + locationText + '</span>';
+        container.insertBefore(div, input.nextSibling);
+        var priceInput = div.querySelector('.priceInput');
+        priceInput.addEventListener('focus', function(){ this.value = this.dataset.val; });
+        priceInput.addEventListener('blur', function(){ this.dataset.val = parseNumber(this.value); this.value = formatNumber(this.dataset.val); updateTotal(); });
+        priceInput.addEventListener('input', function(){ this.dataset.val = parseNumber(this.value); });
+        products.push({priceInput: priceInput});
+        updateTotal();
+        input.value = '';
+        input.focus();
       }
 
       function updateTotal() {
@@ -193,12 +193,15 @@
         finalInput.addEventListener('blur', function(){ this.dataset.val = parseNumber(this.value); this.value = formatNumber(this.dataset.val); });
         google.script.run.withSuccessHandler(function(list){
           var dl = document.getElementById('snList');
-          list.forEach(function(sn){
+          inventoryMap = {};
+          list.forEach(function(item){
+            var key = toEnglishNumber(item.sn).replace(/\s+/g, '');
+            inventoryMap[key] = item;
             var opt = document.createElement('option');
-            opt.value = sn;
+            opt.value = item.sn;
             dl.appendChild(opt);
           });
-        }).getInventorySNList();
+        }).getInventoryData();
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary
- add `getInventoryData` server function
- preload inventory data for faster client-side lookup
- replace per-entry server calls with local search for product info

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68892c3fb014832cb2416f286fc9f506