### PR TITLE
Fix product lookup speed and key handling

### DIFF
--- a/sale.html
+++ b/sale.html
@@ -129,7 +129,7 @@
         input.placeholder = 'کد محصول';
         input.setAttribute('list', 'snList');
         input.addEventListener('keydown', function(e) {
-          if (e.key === 'Enter') {
+          if (e.key === 'Enter' || e.key === 'NumpadEnter') {
             e.preventDefault();
             searchProduct(input);
           }
@@ -166,6 +166,8 @@
           updateTotal();
           input.value = '';
           input.focus();
+        }).withFailureHandler(function(err){
+          alert('خطا: ' + err.message);
         }).searchInventory(sn);
       }
 


### PR DESCRIPTION
## Summary
- cache inventory data in `ProductSale.gs` to avoid repeated sheet scans
- support numpad `Enter` and show dialog errors

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68892c3fb014832cb2416f286fc9f506