### PR TITLE
Improve product search performance

### DIFF
--- a/ProductSale.gs
+++ b/ProductSale.gs
@@ -26,6 +26,33 @@ function getInventorySNList() {
   return values.slice(startIndex).map(function(r){ return r[0]; });
 }
 
+function getInventoryData() {
+  var ss = SpreadsheetApp.getActive();
+  var snRange = ss.getRangeByName('InventorySN');
+  if (!snRange) return [];
+  var sheet = snRange.getSheet();
+  var frozen = sheet.getFrozenRows();
+  var startIndex = Math.max(0, frozen - (snRange.getRow() - 1));
+  var values = snRange.getValues();
+  var data = [];
+  for (var i = startIndex; i < values.length; i++) {
+    var snRaw = values[i][0];
+    if (!snRaw) continue;
+    var snNorm = toEnglishNumber_(snRaw).replace(/\s+/g, '');
+    if (!snNorm) continue;
+    var row = snRange.getCell(i + 1, 1).getRow();
+    data.push({
+      sn: snRaw,
+      snNorm: snNorm,
+      name: getCellValueByName('InventoryName', row),
+      brand: getCellValueByName('InventoryBrand', row),
+      price: getCellValueByName('InventoryPrice', row),
+      location: getCellValueByName('InventoryLocation', row)
+    });
+  }
+  return data;
+}
+
 function toEnglishNumber_(str) {
   return String(str)
     .replace(/[\u06F0-\u06F9]/g, function(d){return d.charCodeAt(0)-1728;})

--- a/sale.html
+++ b/sale.html
@@ -102,6 +102,7 @@
     <script>
     var products = [];
     var container;
+    var inventoryMap = null;
 
     function toEnglishNumber(str) {
       return str.replace(/[\u06F0-\u06F9]/g, function(d){return d.charCodeAt(0)-1728;})
@@ -141,32 +142,43 @@
         input.focus();
       }
 
-      function searchProduct(input) {
-        var sn = toEnglishNumber(input.value).trim();
-        if (!sn) return;
-        google.script.run.withSuccessHandler(function(res) {
-          if (!res) {
+        function searchProduct(input) {
+          var sn = toEnglishNumber(input.value).trim();
+          if (!sn) return;
+          var item = inventoryMap && inventoryMap[sn];
+          if (item) {
+            handleProduct(item, input);
+          } else if (inventoryMap) {
             alert('یافت نشد');
-            return;
+          } else {
+            google.script.run.withSuccessHandler(function(res) {
+              if (!res) {
+                alert('یافت نشد');
+                return;
+              }
+              handleProduct(res, input);
+            }).searchInventory(sn);
           }
-          var div = document.createElement('div');
-          div.className = 'product';
-          var locationText = (res.location === 'STORE') ? 'مغازه' : (res.location || '-');
-          var priceVal = parseNumber(res.price);
-          div.innerHTML = '<span class="label">نام محصول:</span><span>' + (res.name || '-') + '</span>'+
-            '<br><span class="label">برند:</span><span>' + (res.brand || '-') + '</span>'+
-            '<br><span class="label">قیمت:</span><input type="text" class="priceInput" value="' + formatNumber(priceVal) + '" data-val="' + priceVal + '"> تومان'+
-            '<br><span class="label">موقعیت:</span><span>' + locationText + '</span>';
-          container.insertBefore(div, input.nextSibling);
-          var priceInput = div.querySelector('.priceInput');
-          priceInput.addEventListener('focus', function(){ this.value = this.dataset.val; });
-          priceInput.addEventListener('blur', function(){ this.dataset.val = parseNumber(this.value); this.value = formatNumber(this.dataset.val); updateTotal(); });
-          priceInput.addEventListener('input', function(){ this.dataset.val = parseNumber(this.value); });
-          products.push({priceInput: priceInput});
-          updateTotal();
-          input.value = '';
-          input.focus();
-        }).searchInventory(sn);
+        }
+
+      function handleProduct(res, input) {
+        var div = document.createElement('div');
+        div.className = 'product';
+        var locationText = (res.location === 'STORE') ? 'مغازه' : (res.location || '-');
+        var priceVal = parseNumber(res.price);
+        div.innerHTML = '<span class="label">نام محصول:</span><span>' + (res.name || '-') + '</span>'+
+          '<br><span class="label">برند:</span><span>' + (res.brand || '-') + '</span>'+
+          '<br><span class="label">قیمت:</span><input type="text" class="priceInput" value="' + formatNumber(priceVal) + '" data-val="' + priceVal + '"> تومان'+
+          '<br><span class="label">موقعیت:</span><span>' + locationText + '</span>';
+        container.insertBefore(div, input.nextSibling);
+        var priceInput = div.querySelector('.priceInput');
+        priceInput.addEventListener('focus', function(){ this.value = this.dataset.val; });
+        priceInput.addEventListener('blur', function(){ this.dataset.val = parseNumber(this.value); this.value = formatNumber(this.dataset.val); updateTotal(); });
+        priceInput.addEventListener('input', function(){ this.dataset.val = parseNumber(this.value); });
+        products.push({priceInput: priceInput});
+        updateTotal();
+        input.value = '';
+        input.focus();
       }
 
       function updateTotal() {
@@ -192,13 +204,16 @@
         finalInput.addEventListener('focus', function(){ this.value = this.dataset.val; });
         finalInput.addEventListener('blur', function(){ this.dataset.val = parseNumber(this.value); this.value = formatNumber(this.dataset.val); });
         google.script.run.withSuccessHandler(function(list){
+          inventoryMap = {};
           var dl = document.getElementById('snList');
-          list.forEach(function(sn){
+          list.forEach(function(item){
+            var key = toEnglishNumber(item.sn).replace(/\s+/g,'');
+            inventoryMap[key] = item;
             var opt = document.createElement('option');
-            opt.value = sn;
+            opt.value = item.sn;
             dl.appendChild(opt);
           });
-        }).getInventorySNList();
+        }).getInventoryData();
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary
- add `getInventoryData` to retrieve product details in one call
- preload inventory data in `sale.html` for quick client-side search
- look up products locally instead of calling server on every entry

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68892c3fb014832cb2416f286fc9f506