### PR TITLE
Fix product search by cleaning SN values

### DIFF
--- a/ProductSale.gs
+++ b/ProductSale.gs
@@ -43,7 +43,7 @@ function getInventoryData() {
   var data = [];
   for (var i = startIndex; i < snValues.length; i++) {
     var row = snRange.getRow() + i;
-    var sn = toEnglishNumber_(snValues[i][0]).replace(/\s+/g, '');
+    var sn = sanitizeNumber_(snValues[i][0]);
     data.push({
       sn: sn,
       name: getCellValueByName('InventoryName', row),
@@ -61,15 +61,19 @@ function toEnglishNumber_(str) {
     .replace(/[\u0660-\u0669]/g, function(d){return d.charCodeAt(0)-1584;});
 }
 
+function sanitizeNumber_(str) {
+  return toEnglishNumber_(str).replace(/\D+/g, '');
+}
+
 function searchInventory(sn) {
   var ss = SpreadsheetApp.getActive();
   var snRange = ss.getRangeByName('InventorySN');
   if (!snRange) return null;
-  var snNorm = toEnglishNumber_(sn).replace(/\s+/g, '');
+  var snNorm = sanitizeNumber_(sn);
   var snNum = Number(snNorm);
   var values = snRange.getValues();
   for (var i = 0; i < values.length; i++) {
-    var cellVal = toEnglishNumber_(values[i][0]).replace(/\s+/g, '');
+    var cellVal = sanitizeNumber_(values[i][0]);
     var cellNum = Number(cellVal);
     if ((snNum && cellNum && snNum === cellNum) || cellVal === snNorm) {
       var row = snRange.getCell(i + 1, 1).getRow();

--- a/sale.html
+++ b/sale.html
@@ -123,6 +123,10 @@
       return Number(val) || 0;
     }
 
+    function sanitizeNumber(val){
+      return toEnglishNumber(val).replace(/\D+/g,'');
+    }
+
       function addInput() {
         var input = document.createElement('input');
         input.type = 'text';
@@ -163,7 +167,7 @@
       }
 
       function searchProduct(input) {
-        var sn = toEnglishNumber(input.value).trim().replace(/\s+/g, '');
+        var sn = sanitizeNumber(input.value);
         if (!sn) return;
         var res = inventoryMap[sn];
         if (res) {
@@ -210,7 +214,7 @@
           var dl = document.getElementById('snList');
           inventoryMap = {};
           list.forEach(function(item){
-            var key = toEnglishNumber(item.sn).replace(/\s+/g, '');
+            var key = sanitizeNumber(item.sn);
             inventoryMap[key] = item;
             var opt = document.createElement('option');
             opt.value = item.sn;


### PR DESCRIPTION
## Summary
- sanitize inventory numbers to avoid mismatch on search
- use sanitized values in front-end search logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688934f1c044832c9f8edc027b4a585e