### PR TITLE
Fix product search by preloading inventory data

### DIFF
--- a/ProductSale.gs
+++ b/ProductSale.gs
@@ -7,8 +7,8 @@ function onOpen() {
 
 function showSaleDialog() {
   var tpl = HtmlService.createTemplateFromFile('sale');
-  // Load SN list asynchronously on the client to speed up dialog opening
-  tpl.snList = [];
+  // Preload inventory data so search works immediately on the client
+  tpl.snList = getInventoryData();
   var html = tpl.evaluate()
     .setWidth(1200)
     .setHeight(800);

--- a/sale.html
+++ b/sale.html
@@ -100,6 +100,7 @@
     </div>
 
     <script>
+    var inventoryData = <?= JSON.stringify(snList) ?>;
     var products = [];
     var container;
     var inventoryMap = {};
@@ -206,22 +207,24 @@
         finalInput.dataset.val = 0;
         finalInput.addEventListener('focus', function(){ this.value = this.dataset.val; });
         finalInput.addEventListener('blur', function(){ this.dataset.val = parseNumber(this.value); this.value = formatNumber(this.dataset.val); });
-        google.script.run.withSuccessHandler(function(list){
-          var dl = document.getElementById('snList');
-          inventoryMap = {};
-          inventoryNumMap = {};
-          list.forEach(function(item){
-            var key = normalize(item.sn);
-            inventoryMap[key] = item;
-            var n = Number(key);
-            if (!isNaN(n)) {
-              inventoryNumMap[n] = item;
-            }
-            var opt = document.createElement('option');
-            opt.value = item.sn;
-            dl.appendChild(opt);
-          });
-        }).getInventoryData();
+        populateInventory(inventoryData);
+      }
+
+      function populateInventory(list){
+        var dl = document.getElementById('snList');
+        inventoryMap = {};
+        inventoryNumMap = {};
+        list.forEach(function(item){
+          var key = normalize(item.sn);
+          inventoryMap[key] = item;
+          var n = Number(key);
+          if (!isNaN(n)) {
+            inventoryNumMap[n] = item;
+          }
+          var opt = document.createElement('option');
+          opt.value = item.sn;
+          dl.appendChild(opt);
+        });
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary
- preload inventory data in `showSaleDialog` so product codes are available immediately
- inject inventory data into the sale dialog and populate datalist on load

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68893942d784832cb248e5b95f592c47