### PR TITLE
Fix product search speed and dropdown

### DIFF
--- a/ProductSale.gs
+++ b/ProductSale.gs
@@ -7,8 +7,8 @@ function onOpen() {
 
 function showSaleDialog() {
   var tpl = HtmlService.createTemplateFromFile('sale');
-  // Load SN list asynchronously on the client to speed up dialog opening
-  tpl.snList = [];
+  // Pass inventory data directly so lookup works immediately
+  tpl.inventory = getInventoryData();
   var html = tpl.evaluate()
     .setWidth(1200)
     .setHeight(800);

--- a/sale.html
+++ b/sale.html
@@ -100,6 +100,9 @@
     </div>
 
     <script>
+    // Inventory data injected from server
+    var inventoryData = <?!= JSON.stringify(inventory) ?>;
+
     var products = [];
     var container;
     var inventoryMap = {};
@@ -206,22 +209,20 @@
         finalInput.dataset.val = 0;
         finalInput.addEventListener('focus', function(){ this.value = this.dataset.val; });
         finalInput.addEventListener('blur', function(){ this.dataset.val = parseNumber(this.value); this.value = formatNumber(this.dataset.val); });
-        google.script.run.withSuccessHandler(function(list){
-          var dl = document.getElementById('snList');
-          inventoryMap = {};
-          inventoryNumMap = {};
-          list.forEach(function(item){
-            var key = normalize(item.sn);
-            inventoryMap[key] = item;
-            var n = Number(key);
-            if (!isNaN(n)) {
-              inventoryNumMap[n] = item;
-            }
-            var opt = document.createElement('option');
-            opt.value = item.sn;
-            dl.appendChild(opt);
-          });
-        }).getInventoryData();
+        var dl = document.getElementById('snList');
+        inventoryMap = {};
+        inventoryNumMap = {};
+        (inventoryData || []).forEach(function(item){
+          var key = normalize(item.sn);
+          inventoryMap[key] = item;
+          var n = Number(key);
+          if (!isNaN(n)) {
+            inventoryNumMap[n] = item;
+          }
+          var opt = document.createElement('option');
+          opt.value = item.sn;
+          dl.appendChild(opt);
+        });
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary
- pass inventory data directly to sale dialog so lookups are immediate
- populate input datalist from injected inventory data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68893942d784832cb248e5b95f592c47