### PR TITLE
Implement dropdown for product SN

### DIFF
--- a/ProductSale.gs
+++ b/ProductSale.gs
@@ -7,8 +7,10 @@ function onOpen() {
 
 function showSaleDialog() {
   var tpl = HtmlService.createTemplateFromFile('sale');
-  // Load SN list asynchronously on the client to speed up dialog opening
-  tpl.snList = [];
+  // Pre-populate the datalist so the dropdown works even if the
+  // asynchronous call fails. The full inventory data will still be
+  // fetched on the client after the dialog loads.
+  tpl.snList = getInventorySNList();
   var html = tpl.evaluate()
     .setWidth(1200)
     .setHeight(800);

--- a/sale.html
+++ b/sale.html
@@ -86,7 +86,11 @@
     </style>
   </head>
   <body>
-    <datalist id="snList"></datalist>
+    <datalist id="snList">
+      <? snList.forEach(function(sn){ ?>
+        <option value="<?= sn ?>"></option>
+      <? }); ?>
+    </datalist>
     <div id="products"></div>
     <div id="totalDiv">
       جمع کل: <span id="total">0</span> تومان


### PR DESCRIPTION
## Summary
- populate the datalist with inventory serial numbers on page load
- server now injects SN list directly to HTML so dropdown is available immediately

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688940d4e590832c951fd5617f46dd87