### PR TITLE
Fix slow loading sale dialog

### DIFF
--- a/ProductSale.gs
+++ b/ProductSale.gs
@@ -7,10 +7,9 @@ function onOpen() {
 
 function showSaleDialog() {
   var tpl = HtmlService.createTemplateFromFile('sale');
-  // Pre-populate the datalist so the dropdown works even if the
-  // asynchronous call fails. The full inventory data will still be
-  // fetched on the client after the dialog loads.
-  tpl.snList = getInventorySNList();
+  // Load the serial number list asynchronously on the client to avoid
+  // delaying the dialog from opening.
+  tpl.snList = [];
   var html = tpl.evaluate()
     .setWidth(1200)
     .setHeight(800);


### PR DESCRIPTION
## Summary
- open the sale dialog without loading inventory synchronously

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688941c09ef8832cb34f8fcebfb376fe