### PR TITLE
Improve product search fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # PosSheet
+
+This repository contains a Google Apps Script project for managing product sales.
+
+## Debugging tips
+
+If the product search dialog cannot find an item by code, ensure that the
+inventory list is fully loaded. The dialog loads data asynchronously, so waiting
+for the inventory to appear may help. If needed, the search field now falls back
+to a server‑side lookup when local data is missing.
+
+To share or back up the script, open the Apps Script editor and use **File ›
+Download** to obtain a zip archive of the project.

--- a/sale.html
+++ b/sale.html
@@ -181,11 +181,18 @@
             res = inventoryNumMap[n];
           }
         }
-        if (!res) {
-          alert('یافت نشد');
+        if (res) {
+          addProduct(res, input);
           return;
         }
-        addProduct(res, input);
+        // Fallback to server-side search in case data is not yet loaded
+        google.script.run.withSuccessHandler(function(item){
+          if (item) {
+            addProduct(item, input);
+          } else {
+            alert('یافت نشد');
+          }
+        }).searchInventory(sn);
       }
 
       function updateTotal() {


### PR DESCRIPTION
## Summary
- add server-side fallback in `searchProduct` to ensure product codes are found even if inventory data hasn't loaded
- document basic debugging tips in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889467465e8832c88add154eb0b2289