### PR TITLE
Improve inventory load speed

### DIFF
--- a/ProductSale.gs
+++ b/ProductSale.gs
@@ -38,6 +38,13 @@ function getInventorySNList() {
 }
 
 function getInventoryData() {
+  var cache = CacheService.getDocumentCache();
+  var cached = cache.get('inventoryData');
+  if (cached) {
+    debugLog('Returning cached inventory data');
+    return JSON.parse(cached);
+  }
+
   var ss = SpreadsheetApp.getActive();
   var snRange = ss.getRangeByName('InventorySN');
   if (!snRange) return [];
@@ -73,6 +80,7 @@ function getInventoryData() {
       location: locationValues[i] ? locationValues[i][0] : '-'
     });
   }
+  cache.put('inventoryData', JSON.stringify(data), 300);
   return data;
 }
 

--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ to a server‑side lookup when local data is missing.
 
 To share or back up the script, open the Apps Script editor and use **File ›
 Download** to obtain a zip archive of the project.
+
+## Performance
+
+`getInventoryData` now caches inventory rows for a few minutes. This avoids repeatedly reading large ranges from the spreadsheet and speeds up loading the sales dialog.


### PR DESCRIPTION
## Summary
- cache inventory data to avoid repeated Spreadsheet reads
- document the new cache behavior in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688950d50c30832cb722fb5d2ca87626