### PR TITLE
Improve searchProduct logic

### DIFF
--- a/sale.html
+++ b/sale.html
@@ -187,6 +187,17 @@
         if (res) {
           log('found locally');
           addProduct(res, input);
+          // Also check server for updated info
+          google.script.run
+            .withSuccessHandler(function(item){
+              if (item) {
+                log('verified with server');
+              }
+            })
+            .withFailureHandler(function(err){
+              log('server error', err);
+            })
+            .searchInventory(sn);
           return;
         }
         // Fallback to server-side search in case data is not yet loaded


### PR DESCRIPTION
## Summary
- call the server-side `searchInventory` method even when the product is found locally

## Testing
- `node -e "require('fs').readFileSync('sale.html','utf8')"`

------
https://chatgpt.com/codex/tasks/task_e_688955059474832cb75e42d67a0d5c55