### PR TITLE
feat: add dropdown selection for product codes

### DIFF
--- a/ProductSale.gs
+++ b/ProductSale.gs
@@ -16,9 +16,6 @@ function debugLog() {
 function showSaleDialog() {
   debugLog('Opening sale dialog');
   var tpl = HtmlService.createTemplateFromFile('sale');
-  // Load the serial number list asynchronously on the client to avoid
-  // delaying the dialog from opening.
-  tpl.snList = [];
   var html = tpl.evaluate()
     .setWidth(1200)
     .setHeight(800);

--- a/sale.html
+++ b/sale.html
@@ -22,7 +22,7 @@
         width:110px;
         font-weight:bold;
       }
-      #products input.sn {
+      #products .sn {
         width:30%;
         font-size:18px;
         text-align:center;
@@ -86,11 +86,6 @@
     </style>
   </head>
   <body>
-    <datalist id="snList">
-      <? snList.forEach(function(sn){ ?>
-        <option value="<?= sn ?>"></option>
-      <? }); ?>
-    </datalist>
     <div id="products"></div>
     <div id="totalDiv">
       جمع کل: <span id="total">0</span> تومان
@@ -110,6 +105,7 @@
     var container;
     var inventoryMap = {};
     var inventoryNumMap = {};
+    var snOptionsHtml = '';
 
     function toEnglishNumber(str) {
       return str.replace(/[\u06F0-\u06F9]/g, function(d){return d.charCodeAt(0)-1728;})
@@ -135,24 +131,14 @@
     }
 
       function addInput() {
-        var input = document.createElement('input');
-        input.type = 'text';
-        input.className = 'sn';
-        input.placeholder = 'کد محصول';
-        input.setAttribute('list', 'snList');
-        // Using keydown ensures the handler runs even when a datalist option is
-        // selected with Enter, since keyup may be swallowed by the browser.
-        input.addEventListener('keydown', function(e) {
-          var key = e.key || e.keyCode;
-          if (key === 'Enter' || key === 13) {
-            searchProduct(input);
-          }
+        var select = document.createElement('select');
+        select.className = 'sn';
+        select.innerHTML = '<option value="">کد محصول</option>' + snOptionsHtml;
+        select.addEventListener('change', function(){
+          searchProduct(select);
         });
-        input.addEventListener('change', function(){
-          searchProduct(input);
-        });
-        container.appendChild(input);
-        input.focus();
+        container.appendChild(select);
+        select.focus();
       }
 
       function addProduct(res, input) {
@@ -171,7 +157,7 @@
         priceInput.addEventListener('input', function(){ this.dataset.val = parseNumber(this.value); });
         products.push({priceInput: priceInput});
         updateTotal();
-        input.value = '';
+        input.selectedIndex = 0;
         input.focus();
       }
 
@@ -233,9 +219,9 @@
         finalInput.addEventListener('focus', function(){ this.value = this.dataset.val; });
         finalInput.addEventListener('blur', function(){ this.dataset.val = parseNumber(this.value); this.value = formatNumber(this.dataset.val); });
         google.script.run.withSuccessHandler(function(list){
-          var dl = document.getElementById('snList');
           inventoryMap = {};
           inventoryNumMap = {};
+          snOptionsHtml = '';
           list.forEach(function(item){
             var key = normalize(item.sn);
             inventoryMap[key] = item;
@@ -243,10 +229,12 @@
             if (!isNaN(n)) {
               inventoryNumMap[n] = item;
             }
-            var opt = document.createElement('option');
-            opt.value = item.sn;
-            dl.appendChild(opt);
+            snOptionsHtml += '<option value="' + item.sn + '">' + item.sn + '</option>';
           });
+          var select = container.querySelector('select.sn');
+          if (select) {
+            select.innerHTML = '<option value="">کد محصول</option>' + snOptionsHtml;
+          }
           log('inventory loaded', list.length);
         }).getInventoryData();
       }


### PR DESCRIPTION
## Summary
- replace product code text box with dropdown backed by the `InventorySN` range
- load product options on dialog init and show row details when an option is chosen
- remove unused template data in `showSaleDialog`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a1a212b9508332ac43d19048348e01