### PR TITLE
feat: improve product search input

### DIFF
--- a/ProductSale.gs
+++ b/ProductSale.gs
@@ -30,8 +30,13 @@ function getInventorySNList() {
   var frozen = sheet.getFrozenRows();
   var startIndex = Math.max(0, frozen - (range.getRow() - 1));
   var values = range.getValues();
-  debugLog('Inventory SN list loaded', values.length - startIndex);
-  return values.slice(startIndex).map(function(r){ return r[0]; });
+  var list = [];
+  for (var i = startIndex; i < values.length; i++) {
+    var sn = normalizeNumber_(values[i][0]);
+    if (sn) list.push(sn);
+  }
+  debugLog('Inventory SN list loaded', list.length);
+  return list;
 }
 
 function getInventoryData() {

--- a/sale.html
+++ b/sale.html
@@ -87,6 +87,7 @@
   </head>
   <body>
     <div id="products"></div>
+    <datalist id="snList"></datalist>
     <div id="totalDiv">
       جمع کل: <span id="total">0</span> تومان
     </div>
@@ -131,14 +132,21 @@
     }
 
       function addInput() {
-        var select = document.createElement('select');
-        select.className = 'sn';
-        select.innerHTML = '<option value="">کد محصول</option>' + snOptionsHtml;
-        select.addEventListener('change', function(){
-          searchProduct(select);
+        var input = document.createElement('input');
+        input.className = 'sn';
+        input.setAttribute('list', 'snList');
+        input.setAttribute('placeholder', 'کد محصول');
+        input.addEventListener('change', function(){
+          searchProduct(input);
         });
-        container.appendChild(select);
-        select.focus();
+        input.addEventListener('keydown', function(e){
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            searchProduct(input);
+          }
+        });
+        container.appendChild(input);
+        input.focus();
       }
 
       function addProduct(res, input) {
@@ -157,7 +165,7 @@
         priceInput.addEventListener('input', function(){ this.dataset.val = parseNumber(this.value); });
         products.push({priceInput: priceInput});
         updateTotal();
-        input.selectedIndex = 0;
+        input.value = '';
         input.focus();
       }
 
@@ -223,18 +231,17 @@
           inventoryNumMap = {};
           snOptionsHtml = '';
           list.forEach(function(item){
+            if (!item || !item.sn) return;
             var key = normalize(item.sn);
             inventoryMap[key] = item;
             var n = Number(key);
             if (!isNaN(n)) {
               inventoryNumMap[n] = item;
             }
-            snOptionsHtml += '<option value="' + item.sn + '">' + item.sn + '</option>';
+            snOptionsHtml += '<option value="' + item.sn + '"></option>';
           });
-          var select = container.querySelector('select.sn');
-          if (select) {
-            select.innerHTML = '<option value="">کد محصول</option>' + snOptionsHtml;
-          }
+          var dl = document.getElementById('snList');
+          dl.innerHTML = snOptionsHtml;
           log('inventory loaded', list.length);
         }).getInventoryData();
       }


### PR DESCRIPTION
## Summary
- replace product code dropdown with an editable input backed by datalist for barcode scanners
- add enter-key handling to trigger product lookup and show details
- filter inventory list to exclude headers and blanks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a1a76cfd348332bee9263f2252d416