### PR TITLE
Preload inventory data and show lookup results in sale dialog

### DIFF
--- a/ProductSale.gs
+++ b/ProductSale.gs
@@ -6,7 +6,26 @@ function onOpen() {
 }
 
 function showSaleDialog() {
-  var html = HtmlService.createHtmlOutputFromFile('sale')
+  var ss = SpreadsheetApp.getActive();
+  var snRange = ss.getRangeByName('InventorySN').getValues();
+  var nameRange = ss.getRangeByName('InventoryName').getValues();
+  var locRange = ss.getRangeByName('InventoryLocation').getValues();
+  var priceRange = ss.getRangeByName('InventoryPrice').getValues();
+
+  var inventory = { sns: [], names: [], locations: [], prices: [] };
+  for (var i = 1; i < snRange.length; i++) {
+    var sn = snRange[i][0];
+    if (sn) {
+      inventory.sns.push(sn);
+      inventory.names.push(nameRange[i][0]);
+      inventory.locations.push(locRange[i][0]);
+      inventory.prices.push(priceRange[i][0]);
+    }
+  }
+
+  var template = HtmlService.createTemplateFromFile('sale');
+  template.inventory = inventory;
+  var html = template.evaluate()
     .setWidth(1200)
     .setHeight(800);
   SpreadsheetApp.getUi().showModalDialog(html, 'فروش محصول');

--- a/sale.html
+++ b/sale.html
@@ -83,11 +83,20 @@
         background:#f44336;
         color:#fff;
       }
+      table { width:80%; margin:10px auto; border-collapse:collapse; background:#fff; }
+      th, td { border:1px solid #ccc; padding:6px 10px; text-align:center; }
+      th { background:#eee; }
     </style>
   </head>
   <body>
     <div id="products">
       <input class="sn" list="snList" placeholder="کد محصول">
+      <table id="resultTable">
+        <thead>
+          <tr><th>محصول</th><th>موقعیت</th><th>قیمت</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
     </div>
     <datalist id="snList"></datalist>
     <div id="totalDiv">
@@ -100,5 +109,36 @@
       <button class="submit">ثبت</button>
       <button class="cancel" onclick="google.script.host.close()">لغو</button>
     </div>
+    <script>
+      const inventory = <?!= JSON.stringify(inventory) ?>;
+      const snMap = new Map(inventory.sns.map((sn,i)=>[sn,i]));
+      const snInput = document.querySelector('#products .sn');
+      const snList = document.getElementById('snList');
+      const tbody = document.querySelector('#resultTable tbody');
+      inventory.sns.forEach(sn => {
+        const opt = document.createElement('option');
+        opt.value = sn;
+        snList.appendChild(opt);
+      });
+      let total = 0;
+      snInput.addEventListener('keydown', e => {
+        if (e.key === 'Enter') {
+          const code = snInput.value.trim();
+          const idx = snMap.get(code);
+          if (idx !== undefined) {
+            const tr = document.createElement('tr');
+            const name = inventory.names[idx] || '';
+            const loc = inventory.locations[idx] || '';
+            const price = inventory.prices[idx] || 0;
+            tr.innerHTML = `<td>${name}</td><td>${loc}</td><td>${price}</td>`;
+            tbody.appendChild(tr);
+            total += Number(price) || 0;
+            document.getElementById('total').textContent = total;
+            document.getElementById('finalAmount').value = total;
+          }
+          snInput.value = '';
+        }
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Preload inventory ranges in `showSaleDialog` for faster lookups.
- Add product details table and client-side search using preloaded data.
- Update totals as products are entered.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a1b53d37788332b6f379b15519a376