### PR TITLE
Enhance sales form styling and layout

### DIFF
--- a/sale.html
+++ b/sale.html
@@ -31,6 +31,10 @@
         padding:8px;
         border-radius:6px;
         border:1px solid #aaa;
+        position: sticky;
+        top: 0;
+        background:#fff;
+        z-index: 1;
       }
       .priceInput {
         width:150px;
@@ -38,6 +42,7 @@
         border-radius:4px;
         border:1px solid #aaa;
         text-align:center;
+        font-weight:bold;
       }
       #productTable {
         width:100%;
@@ -52,22 +57,27 @@
       #productTable th {
         background:#eee;
       }
-      #totalDiv, #finalAmountDiv {
+      #productTable td.price {
+        font-weight:bold;
+      }
+      #totals {
         position: fixed;
         left: 0;
         right: 0;
+        bottom:60px;
         background:#fff;
         border-top:1px solid #ccc;
-        text-align:center;
+      }
+      #totalDiv, #finalAmountDiv {
         padding:10px;
+        text-align:center;
+        border-top:1px solid #ccc;
       }
       #totalDiv {
-        bottom:120px;
         font-size:20px;
         font-weight:bold;
       }
       #finalAmountDiv {
-        bottom:60px;
         font-size:18px;
       }
       #finalAmount {
@@ -76,6 +86,7 @@
         border-radius:4px;
         border:1px solid #aaa;
         text-align:center;
+        font-weight:bold;
       }
       #footer {
         position: fixed;
@@ -121,11 +132,13 @@
       </table>
     </div>
     <datalist id="snList"></datalist>
-    <div id="totalDiv">
-      جمع کل: <span id="total">0</span> تومان
-    </div>
-    <div id="finalAmountDiv">
-      مبلغ نهایی: <input id="finalAmount" type="text" value="0"> تومان
+    <div id="totals">
+      <div id="totalDiv">
+        جمع کل: <span id="total">0</span> تومان
+      </div>
+      <div id="finalAmountDiv">
+        مبلغ نهایی: <input id="finalAmount" type="text" value="0"> تومان
+      </div>
     </div>
     <div id="footer">
       <button class="submit">ثبت</button>
@@ -164,8 +177,9 @@
           const idx = snIndex[code];
           if(idx !== undefined){
             const price = Number(inventoryData.prices[idx]) || 0;
+            const location = inventoryData.locations[idx] === 'STORE' ? 'مغازه' : inventoryData.locations[idx];
             const row = document.createElement('tr');
-            row.innerHTML = `<td>${inventoryData.names[idx]}</td><td>${inventoryData.sns[idx]}</td><td>${inventoryData.locations[idx]}</td><td>${formatNumber(price)}</td>`;
+            row.innerHTML = `<td>${inventoryData.names[idx]}</td><td>${inventoryData.sns[idx]}</td><td>${location}</td><td class="price">${formatNumber(price)}</td>`;
             tbody.appendChild(row);
             total += price;
             totalEl.textContent = formatNumber(total);


### PR DESCRIPTION
## Summary
- Make product code input stick to the top while scrolling
- Emphasize price amounts and bold final amount field
- Stack total and final amount sections without gaps and translate STORE location

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a1d1c031108332879c0f691ab7bcfe