### PR TITLE
Prevent duplicate serial numbers in sale dialog

### DIFF
--- a/sale.html
+++ b/sale.html
@@ -157,6 +157,7 @@
       const tbody = document.querySelector('#productTable tbody');
       const totalEl = document.getElementById('total');
       const finalAmountInput = document.getElementById('finalAmount');
+      const addedSerials = new Set();
 
       const persianDigits = '۰۱۲۳۴۵۶۷۸۹';
       function formatNumber(num){
@@ -176,11 +177,17 @@
           if(!code) return;
           const idx = snIndex[code];
           if(idx !== undefined){
+            if (addedSerials.has(code)) {
+              alert('سریال تکراری است');
+              snInput.value = '';
+              return;
+            }
             const price = Number(inventoryData.prices[idx]) || 0;
             const location = inventoryData.locations[idx] === 'STORE' ? 'مغازه' : inventoryData.locations[idx];
             const row = document.createElement('tr');
             row.innerHTML = `<td>${inventoryData.names[idx]}</td><td>${inventoryData.sns[idx]}</td><td>${location}</td><td class="price">${formatNumber(price)}</td>`;
             tbody.appendChild(row);
+            addedSerials.add(code);
             total += price;
             totalEl.textContent = formatNumber(total);
             finalAmountInput.value = formatNumber(total);


### PR DESCRIPTION
## Summary
- Track added product serial numbers in sale dialog
- Alert and skip when a duplicate serial is entered

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a1d342fcd48332af3403cafbc85bcc