### PR TITLE
feat: enhance product search field

### DIFF
--- a/sale.html
+++ b/sale.html
@@ -118,7 +118,7 @@
   </head>
   <body>
     <div id="products">
-      <input class="sn" list="snList" placeholder="کد محصول">
+      <input class="sn" list="productList" placeholder="جستجوی محصول">
       <table id="productTable">
         <thead>
           <tr>
@@ -131,7 +131,7 @@
         <tbody></tbody>
       </table>
     </div>
-    <datalist id="snList"></datalist>
+    <datalist id="productList"></datalist>
     <div id="totals">
       <div id="totalDiv">
         جمع کل: <span id="total">0</span> تومان
@@ -147,11 +147,17 @@
     <script>
       const inventoryData = <?!= JSON.stringify(inventoryData) ?>;
       const snIndex = inventoryData.sns.reduce((o, sn, i) => (o[sn] = i, o), {});
-      const snList = document.getElementById('snList');
+      const nameIndex = inventoryData.names.reduce((o, name, i) => (o[name.toLowerCase()] = i, o), {});
+      const productList = document.getElementById('productList');
       inventoryData.sns.forEach(sn => {
         const opt = document.createElement('option');
         opt.value = sn;
-        snList.appendChild(opt);
+        productList.appendChild(opt);
+      });
+      inventoryData.names.forEach(name => {
+        const opt = document.createElement('option');
+        opt.value = name;
+        productList.appendChild(opt);
       });
       const snInput = document.querySelector('.sn');
       const tbody = document.querySelector('#productTable tbody');
@@ -173,21 +179,24 @@
 
       snInput.addEventListener('keydown', function(e){
         if(e.key === 'Enter'){
-          const code = snInput.value.trim();
-          if(!code) return;
-          const idx = snIndex[code];
+          const query = snInput.value.trim();
+          if(!query) return;
+          let idx = snIndex[query];
+          if(idx === undefined){
+            idx = nameIndex[query.toLowerCase()];
+          }
           if(idx !== undefined){
-            if (addedSerials.has(code)) {
-              alert('سریال تکراری است');
+            const serial = inventoryData.sns[idx];
+            if (addedSerials.has(serial)) {
               snInput.value = '';
               return;
             }
             const price = Number(inventoryData.prices[idx]) || 0;
             const location = inventoryData.locations[idx] === 'STORE' ? 'مغازه' : inventoryData.locations[idx];
             const row = document.createElement('tr');
-            row.innerHTML = `<td>${inventoryData.names[idx]}</td><td>${inventoryData.sns[idx]}</td><td>${location}</td><td class="price">${formatNumber(price)}</td>`;
+            row.innerHTML = `<td>${inventoryData.names[idx]}</td><td>${serial}</td><td>${location}</td><td class="price">${formatNumber(price)}</td>`;
             tbody.appendChild(row);
-            addedSerials.add(code);
+            addedSerials.add(serial);
             total += price;
             totalEl.textContent = formatNumber(total);
             finalAmountInput.value = formatNumber(total);


### PR DESCRIPTION
## Summary
- allow searching products by serial number or name in sale dialog
- suppress duplicate serial alerts and skip adding duplicate rows

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_68a1d5ef600c8332818a462b47b40a1b