### PR TITLE
Remove sold product from search options

### DIFF
--- a/sale.html
+++ b/sale.html
@@ -146,19 +146,25 @@
     </div>
     <script>
       const inventoryData = <?!= JSON.stringify(inventoryData) ?>;
-      const snIndex = inventoryData.sns.reduce((o, sn, i) => (o[sn] = i, o), {});
-      const nameIndex = inventoryData.names.reduce((o, name, i) => (o[name.toLowerCase()] = i, o), {});
+      let snIndex = inventoryData.sns.reduce((o, sn, i) => (o[sn] = i, o), {});
+      let nameIndex = inventoryData.names.reduce((o, name, i) => (o[name.toLowerCase()] = i, o), {});
       const productList = document.getElementById('productList');
-      inventoryData.sns.forEach(sn => {
-        const opt = document.createElement('option');
-        opt.value = sn;
-        productList.appendChild(opt);
-      });
-      inventoryData.names.forEach(name => {
-        const opt = document.createElement('option');
-        opt.value = name;
-        productList.appendChild(opt);
-      });
+
+      function rebuildDropdown(){
+        productList.innerHTML = '';
+        inventoryData.sns.forEach(sn => {
+          const opt = document.createElement('option');
+          opt.value = sn;
+          productList.appendChild(opt);
+        });
+        inventoryData.names.forEach(name => {
+          const opt = document.createElement('option');
+          opt.value = name;
+          productList.appendChild(opt);
+        });
+      }
+
+      rebuildDropdown();
       const snInput = document.querySelector('.sn');
       const tbody = document.querySelector('#productTable tbody');
       const totalEl = document.getElementById('total');
@@ -191,16 +197,28 @@
               snInput.value = '';
               return;
             }
+            const name = inventoryData.names[idx];
             const price = Number(inventoryData.prices[idx]) || 0;
             const location = inventoryData.locations[idx] === 'STORE' ? 'مغازه' : inventoryData.locations[idx];
             const row = document.createElement('tr');
-            row.innerHTML = `<td>${inventoryData.names[idx]}</td><td>${serial}</td><td>${location}</td><td class="price">${formatNumber(price)}</td>`;
+            row.innerHTML = `<td>${name}</td><td>${serial}</td><td>${location}</td><td class="price">${formatNumber(price)}</td>`;
             tbody.appendChild(row);
             addedSerials.add(serial);
             total += price;
             totalEl.textContent = formatNumber(total);
             finalAmountInput.value = formatNumber(total);
             snInput.value = '';
+
+            // remove product data from arrays
+            inventoryData.names.splice(idx, 1);
+            inventoryData.sns.splice(idx, 1);
+            inventoryData.locations.splice(idx, 1);
+            inventoryData.prices.splice(idx, 1);
+
+            // rebuild lookup indexes and dropdown
+            snIndex = inventoryData.sns.reduce((o, sn, i) => (o[sn] = i, o), {});
+            nameIndex = inventoryData.names.reduce((o, n, i) => (o[n.toLowerCase()] = i, o), {});
+            rebuildDropdown();
           }
         }
       });


### PR DESCRIPTION
## Summary
- rebuild dropdown options after each sale to exclude sold product
- refresh lookup indices alongside inventory arrays

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a1db9df45483329bc6bceee1ef569a