### PR TITLE
Deduplicate product names and cycle serial numbers during sales

### DIFF
--- a/sale.html
+++ b/sale.html
@@ -146,24 +146,26 @@
     </div>
     <script>
       const inventoryData = <?!= JSON.stringify(inventoryData) ?>;
-      const snIndex = inventoryData.sns.reduce((o, sn, i) => (o[sn] = i, o), {});
-      const nameIndex = inventoryData.names.reduce((o, name, i) => (o[name.toLowerCase()] = i, o), {});
       const productList = document.getElementById('productList');
       inventoryData.sns.forEach(sn => {
         const opt = document.createElement('option');
         opt.value = sn;
         productList.appendChild(opt);
       });
+      const nameSet = new Set();
       inventoryData.names.forEach(name => {
-        const opt = document.createElement('option');
-        opt.value = name;
-        productList.appendChild(opt);
+        const lower = name.toLowerCase();
+        if (!nameSet.has(lower)) {
+          nameSet.add(lower);
+          const opt = document.createElement('option');
+          opt.value = name;
+          productList.appendChild(opt);
+        }
       });
       const snInput = document.querySelector('.sn');
       const tbody = document.querySelector('#productTable tbody');
       const totalEl = document.getElementById('total');
       const finalAmountInput = document.getElementById('finalAmount');
-      const addedSerials = new Set();
 
       const persianDigits = '۰۱۲۳۴۵۶۷۸۹';
       function formatNumber(num){
@@ -181,26 +183,27 @@
         if(e.key === 'Enter'){
           const query = snInput.value.trim();
           if(!query) return;
-          let idx = snIndex[query];
-          if(idx === undefined){
-            idx = nameIndex[query.toLowerCase()];
+          let idx = inventoryData.sns.findIndex(sn => sn === query);
+          if(idx === -1){
+            idx = inventoryData.names.findIndex(name => name.toLowerCase() === query.toLowerCase());
           }
-          if(idx !== undefined){
+          if(idx !== -1){
             const serial = inventoryData.sns[idx];
-            if (addedSerials.has(serial)) {
-              snInput.value = '';
-              return;
-            }
             const price = Number(inventoryData.prices[idx]) || 0;
             const location = inventoryData.locations[idx] === 'STORE' ? 'مغازه' : inventoryData.locations[idx];
             const row = document.createElement('tr');
             row.innerHTML = `<td>${inventoryData.names[idx]}</td><td>${serial}</td><td>${location}</td><td class="price">${formatNumber(price)}</td>`;
             tbody.appendChild(row);
-            addedSerials.add(serial);
             total += price;
             totalEl.textContent = formatNumber(total);
             finalAmountInput.value = formatNumber(total);
             snInput.value = '';
+
+            // remove used entry to reveal next serial on repeated selection
+            inventoryData.names.splice(idx,1);
+            inventoryData.sns.splice(idx,1);
+            inventoryData.locations.splice(idx,1);
+            inventoryData.prices.splice(idx,1);
           }
         }
       });


### PR DESCRIPTION
## Summary
- Avoid duplicate product names in search suggestions
- Use first available serial for a selected name and remove it from inventory arrays

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a208f06f5483329342ee96819e1bac