### PR TITLE
feat: allow manual override of final amount

### DIFF
--- a/sale.html
+++ b/sale.html
@@ -152,7 +152,7 @@
         جمع کل: <span id="total">0</span> تومان
       </div>
       <div id="finalAmountDiv">
-        مبلغ نهایی: <input id="finalAmount" type="text" value="" placeholder="0" readonly> تومان
+        مبلغ نهایی: <input id="finalAmount" type="text" value="" placeholder="0"> تومان
         <div id="finalDiscountInfo"></div>
       </div>
     </div>
@@ -181,6 +181,7 @@
       const finalAmountInput = document.getElementById('finalAmount');
       const finalDiscountInfo = document.getElementById('finalDiscountInfo');
       const addedSerials = new Set();
+      let manualFinalAmount = false;
 
       const persianDigits = '۰۱۲۳۴۵۶۷۸۹';
       function formatNumber(num){
@@ -194,6 +195,19 @@
       totalEl.textContent = formatNumber(total);
       finalAmountInput.placeholder = formatNumber(total);
       finalAmountInput.value = '';
+      finalAmountInput.addEventListener('input', function(){
+        const raw = finalAmountInput.value;
+        if(raw.trim() === ''){
+          manualFinalAmount = false;
+          finalAmountInput.value = '';
+          updateTotals();
+        } else {
+          manualFinalAmount = true;
+          const val = parseNumber(raw);
+          finalAmountInput.value = formatNumber(val);
+          updateFinalDiscount(total, val);
+        }
+      });
 
       function updateTotals(){
         total = Array.from(document.querySelectorAll('#productTable tbody tr .price'))
@@ -206,12 +220,15 @@
           }, 0);
         totalEl.textContent = formatNumber(total);
         finalAmountInput.placeholder = formatNumber(total);
-        if(finalTotal === total){
-          finalAmountInput.value = '';
-        } else {
-          finalAmountInput.value = formatNumber(finalTotal);
+        if(!manualFinalAmount){
+          if(finalTotal === total){
+            finalAmountInput.value = '';
+          } else {
+            finalAmountInput.value = formatNumber(finalTotal);
+          }
         }
-        updateFinalDiscount(total, finalTotal);
+        const displayedFinal = manualFinalAmount ? parseNumber(finalAmountInput.value) || 0 : finalTotal;
+        updateFinalDiscount(total, displayedFinal);
       }
 
       function updateFinalDiscount(total, finalTotal){


### PR DESCRIPTION
## Summary
- enable manual editing of final amount in sale dialog
- track user-entered totals and recalculate overall discount

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a237d398548332838607af6dcffb87