### PR TITLE
feat: add row numbers and delete option

### DIFF
--- a/sale.html
+++ b/sale.html
@@ -66,6 +66,17 @@
       #productTable td.price {
         font-weight:bold;
       }
+      .remove-btn {
+        background:none;
+        border:none;
+        cursor:pointer;
+        color:#d32f2f;
+      }
+      .remove-btn svg {
+        width:20px;
+        height:20px;
+        pointer-events:none;
+      }
       #totals {
         position: fixed;
         left: 0;
@@ -143,11 +154,13 @@
       <table id="productTable">
         <thead>
           <tr>
+            <th>ردیف</th>
             <th>محصول</th>
             <th>سریال</th>
             <th>موقعیت</th>
             <th>قیمت</th>
             <th>قیمت با تخفیف</th>
+            <th>حذف</th>
           </tr>
         </thead>
         <tbody></tbody>
@@ -323,6 +336,15 @@
         }
       }
 
+      function updateRowNumbers(){
+        document.querySelectorAll('#productTable tbody tr').forEach((row, idx) => {
+          const cell = row.querySelector('.row-number');
+          if(cell){
+            cell.textContent = idx + 1;
+          }
+        });
+      }
+
       snInput.addEventListener('keydown', function(e){
         if(e.key === 'Enter'){
           const query = snInput.value.trim();
@@ -340,12 +362,15 @@
             const price = Number(inventoryData.prices[idx]) || 0;
             const location = inventoryData.locations[idx] === 'STORE' ? 'مغازه' : inventoryData.locations[idx];
               const row = document.createElement('tr');
+              row.dataset.serial = serial;
               row.innerHTML =
+                `<td class="row-number"></td>` +
                 `<td>${inventoryData.names[idx]}</td>` +
                 `<td>${serial}</td>` +
                 `<td>${location}</td>` +
                 `<td class="price">${formatNumber(price)}</td>` +
-                `<td><input class="priceInput discount" type="text" placeholder="${formatNumber(price)}"><div class="discount-info"></div></td>`;
+                `<td><input class="priceInput discount" type="text" placeholder="${formatNumber(price)}"><div class="discount-info"></div></td>` +
+                `<td><button class="remove-btn" title="حذف"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6m5-3h4a2 2 0 0 1 2 2v1H8V5a2 2 0 0 1 2-2z"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg></button></td>`;
               tbody.appendChild(row);
               addedSerials.add(serial);
               const discountInput = row.querySelector('.discount');
@@ -368,8 +393,16 @@
                 updateRowDiscount(row);
                 updateTotals();
               });
+              const removeBtn = row.querySelector('.remove-btn');
+              removeBtn.addEventListener('click', function(){
+                addedSerials.delete(serial);
+                row.remove();
+                updateTotals();
+                updateRowNumbers();
+              });
               updateRowDiscount(row);
               updateTotals();
+              updateRowNumbers();
               snInput.value = '';
             }
           }


### PR DESCRIPTION
## Summary
- show sequential item numbers in sales table
- add red trash icon to remove items and renumber rows automatically

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a2467c7c608332b450991e72847d31