### PR TITLE
Enhance product search modal for inventory selection

### DIFF
--- a/sale.html
+++ b/sale.html
@@ -81,6 +81,56 @@
         height:20px;
         pointer-events:none;
       }
+      #selectionModal {
+        display:none;
+        position:fixed;
+        top:0;
+        left:0;
+        right:0;
+        bottom:0;
+        background:rgba(0,0,0,0.5);
+        justify-content:center;
+        align-items:center;
+        z-index:2;
+      }
+      #selectionModal .modal-content {
+        background:#fff;
+        padding:20px;
+        border-radius:8px;
+        max-height:80%;
+        overflow:auto;
+        min-width:300px;
+        box-shadow:0 2px 10px rgba(0,0,0,0.3);
+        text-align:center;
+      }
+      #selectionModal table {
+        width:100%;
+        border-collapse:collapse;
+        margin-top:10px;
+      }
+      #selectionModal th, #selectionModal td {
+        border:1px solid #ccc;
+        padding:8px;
+        text-align:center;
+      }
+      #selectionModal .modal-actions {
+        margin-top:10px;
+      }
+      #selectionModal .modal-actions button {
+        margin:0 5px;
+        padding:8px 16px;
+        border:none;
+        border-radius:4px;
+        cursor:pointer;
+      }
+      #selectionModal .modal-actions button.add {
+        background:#4caf50;
+        color:#fff;
+      }
+      #selectionModal .modal-actions button.cancel {
+        background:#f44336;
+        color:#fff;
+      }
       #totals {
         position: fixed;
         left: 0;
@@ -172,6 +222,25 @@
       </table>
     </div>
     <datalist id="productList"></datalist>
+    <div id="selectionModal">
+      <div class="modal-content">
+        <h3>محصولات یافت شده</h3>
+        <table>
+          <thead>
+            <tr>
+              <th>انتخاب</th>
+              <th>سریال</th>
+              <th>موقعیت</th>
+            </tr>
+          </thead>
+          <tbody id="selectionList"></tbody>
+        </table>
+        <div class="modal-actions">
+          <button id="addSelected" class="add">افزودن</button>
+          <button id="cancelSelection" class="cancel">انصراف</button>
+        </div>
+      </div>
+    </div>
     <div id="totals">
       <div id="totalDiv">
         جمع کل: <span id="total">0</span> تومان
@@ -215,6 +284,10 @@
       const finalAmountReminder = document.getElementById('finalAmountReminder');
       const addedSerials = new Set();
       let manualFinalAmount = false;
+      const selectionModal = document.getElementById('selectionModal');
+      const selectionList = document.getElementById('selectionList');
+      const addSelectedBtn = document.getElementById('addSelected');
+      const cancelSelectionBtn = document.getElementById('cancelSelection');
 
       const persianDigits = '۰۱۲۳۴۵۶۷۸۹';
       function formatNumber(num){
@@ -369,77 +442,112 @@
         });
       }
 
+      function addProduct(idx){
+        const serial = inventoryData.sns[idx];
+        if (addedSerials.has(serial)) return;
+        const price = Number(inventoryData.prices[idx]) || 0;
+        const location = inventoryData.locations[idx] === 'STORE' ? 'مغازه' : inventoryData.locations[idx];
+        const productName = inventoryData.names[idx];
+        const inventoryCount = inventoryCounts[productName];
+        const row = document.createElement('tr');
+        row.dataset.serial = serial;
+        row.dataset.productName = productName;
+        row.innerHTML =
+            `<td class="row-number"></td>` +
+            `<td>${productName}</td>` +
+            `<td>${serial}</td>` +
+            `<td>${location}</td>` +
+            `<td class="price">${formatNumber(price)}</td>` +
+            `<td><input class="priceInput discount" type="text" placeholder="${formatNumber(price)}"><div class="discount-info"></div></td>` +
+            `<td><button class="remove-btn" title="حذف"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6m5-3h4a2 2 0 0 1 2 2v1H8V5a2 2 0 0 1 2-2z"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg></button></td>` +
+            `<td class="inventory">${inventoryCount}</td>`;
+        tbody.appendChild(row);
+        addedSerials.add(serial);
+        const discountInput = row.querySelector('.discount');
+        discountInput.dataset.auto = 'true';
+        discountInput.addEventListener('focus', function(){
+          if(this.value.trim() !== ''){
+            setTimeout(() => this.select(), 0);
+          }
+        });
+        discountInput.addEventListener('input', function(){
+          const raw = discountInput.value;
+          if(raw.trim() === ''){
+            discountInput.dataset.auto = 'true';
+            discountInput.value = '';
+          } else {
+            discountInput.dataset.auto = 'false';
+            const val = parseNumber(raw);
+            discountInput.value = formatNumber(val);
+          }
+          updateRowDiscount(row);
+          updateTotals();
+        });
+        const removeBtn = row.querySelector('.remove-btn');
+        removeBtn.addEventListener('click', function(){
+          addedSerials.delete(serial);
+          row.remove();
+          updateTotals();
+          updateRowNumbers();
+          updateInventoryDisplay();
+        });
+        updateRowDiscount(row);
+        updateTotals();
+        updateRowNumbers();
+        updateInventoryDisplay();
+      }
+
+      function openSelectionModal(indices){
+        selectionList.innerHTML = '';
+        indices.forEach(i => {
+          const serial = inventoryData.sns[i];
+          const location = inventoryData.locations[i] === 'STORE' ? 'مغازه' : inventoryData.locations[i];
+          const tr = document.createElement('tr');
+          tr.innerHTML = `<td><input type="checkbox" value="${i}"></td><td>${serial}</td><td>${location}</td>`;
+          selectionList.appendChild(tr);
+        });
+        selectionModal.style.display = 'flex';
+        addSelectedBtn.onclick = () => {
+          const selected = Array.from(selectionList.querySelectorAll('input[type="checkbox"]:checked')).map(cb => parseInt(cb.value));
+          selected.forEach(addProduct);
+          closeSelectionModal();
+        };
+        cancelSelectionBtn.onclick = closeSelectionModal;
+      }
+
+      function closeSelectionModal(){
+        selectionModal.style.display = 'none';
+        selectionList.innerHTML = '';
+        snInput.focus();
+      }
+
+      selectionModal.addEventListener('click', function(e){
+        if(e.target === selectionModal) closeSelectionModal();
+      });
+
       snInput.addEventListener('keydown', function(e){
         if(e.key === 'Enter'){
           const query = snInput.value.trim();
           if(!query) return;
-          let idx = snIndex[query];
-          if(idx === undefined){
-            const indices = nameIndex[query.toLowerCase()];
-            if(indices){
-              idx = indices.find(i => !addedSerials.has(inventoryData.sns[i]));
-            }
-          }
+          const idx = snIndex[query];
           if(idx !== undefined){
-            const serial = inventoryData.sns[idx];
-            if (addedSerials.has(serial)) {
-              snInput.value = '';
-              return;
-            }
-            const price = Number(inventoryData.prices[idx]) || 0;
-            const location = inventoryData.locations[idx] === 'STORE' ? 'مغازه' : inventoryData.locations[idx];
-            const productName = inventoryData.names[idx];
-            const inventoryCount = inventoryCounts[productName];
-            const row = document.createElement('tr');
-            row.dataset.serial = serial;
-            row.dataset.productName = productName;
-            row.innerHTML =
-                `<td class="row-number"></td>` +
-                `<td>${productName}</td>` +
-                `<td>${serial}</td>` +
-                `<td>${location}</td>` +
-                `<td class="price">${formatNumber(price)}</td>` +
-                `<td><input class="priceInput discount" type="text" placeholder="${formatNumber(price)}"><div class="discount-info"></div></td>` +
-                `<td><button class="remove-btn" title="حذف"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6m5-3h4a2 2 0 0 1 2 2v1H8V5a2 2 0 0 1 2-2z"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg></button></td>` +
-                `<td class="inventory">${inventoryCount}</td>`;
-              tbody.appendChild(row);
-              addedSerials.add(serial);
-              const discountInput = row.querySelector('.discount');
-              discountInput.dataset.auto = 'true';
-              discountInput.addEventListener('focus', function(){
-                if(this.value.trim() !== ''){
-                  setTimeout(() => this.select(), 0);
-                }
-              });
-              discountInput.addEventListener('input', function(){
-                const raw = discountInput.value;
-                if(raw.trim() === ''){
-                  discountInput.dataset.auto = 'true';
-                  discountInput.value = '';
-                } else {
-                  discountInput.dataset.auto = 'false';
-                  const val = parseNumber(raw);
-                  discountInput.value = formatNumber(val);
-                }
-                updateRowDiscount(row);
-                updateTotals();
-              });
-              const removeBtn = row.querySelector('.remove-btn');
-              removeBtn.addEventListener('click', function(){
-                addedSerials.delete(serial);
-                row.remove();
-                updateTotals();
-                updateRowNumbers();
-                updateInventoryDisplay();
-              });
-              updateRowDiscount(row);
-              updateTotals();
-              updateRowNumbers();
-              updateInventoryDisplay();
-              snInput.value = '';
-            }
+            addProduct(idx);
+            snInput.value = '';
+            snInput.focus();
+            return;
           }
-        });
+          const indices = nameIndex[query.toLowerCase()];
+          if(indices){
+            const available = indices.filter(i => !addedSerials.has(inventoryData.sns[i]));
+            if(available.length){
+              openSelectionModal(available);
+            }
+            snInput.value = '';
+          }
+        }
+      });
+
+      setTimeout(() => snInput.focus(), 0);
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Autofocus search field on dialog open for quicker entry
- Show modal listing matching serials and locations when searching by product name
- Allow multi-select additions or cancel without changes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a2561aa6e48332b2044ae26a65bdeb