### PR TITLE
Add lightning-fast order logging with Jalali timestamps

### DIFF
--- a/ProductSale.gs
+++ b/ProductSale.gs
@@ -20,3 +20,78 @@ function showSaleDialog() {
     .setHeight(800);
   SpreadsheetApp.getUi().showModalDialog(html, 'فروش محصول');
 }
+
+function submitOrder(items) {
+  if (!items || !items.length) {
+    return;
+  }
+  var ss = SpreadsheetApp.getActive();
+  var idRange = ss.getRangeByName('OrderID');
+  var sheet = idRange.getSheet();
+  var idCol = idRange.getColumn();
+  var nameCol = ss.getRangeByName('OrderName').getColumn();
+  var skuCol = ss.getRangeByName('OrderSKU').getColumn();
+  var snCol = ss.getRangeByName('OrderSN').getColumn();
+  var dateCol = ss.getRangeByName('OrderDate').getColumn();
+  var priceCol = ss.getRangeByName('OrderPrice').getColumn();
+  var paidCol = ss.getRangeByName('OrderPaidPrice').getColumn();
+  var nextRow = sheet.getLastRow() + 1;
+  var lastId = sheet.getRange(nextRow - 1, idCol).getValue();
+  var orderId = lastId ? Number(lastId) + 1 : 1;
+  var ids = [], names = [], skus = [], sns = [], dates = [], prices = [], paid = [];
+  var dateStr = getPersianDateTime();
+  items.forEach(function(it) {
+    ids.push([orderId]);
+    names.push([it.name]);
+    skus.push([it.sku]);
+    sns.push([it.serial]);
+    dates.push([dateStr]);
+    prices.push([it.price]);
+    paid.push([it.paid]);
+  });
+  sheet.getRange(nextRow, idCol, items.length, 1).setValues(ids);
+  sheet.getRange(nextRow, nameCol, items.length, 1).setValues(names);
+  sheet.getRange(nextRow, skuCol, items.length, 1).setValues(skus);
+  sheet.getRange(nextRow, snCol, items.length, 1).setValues(sns);
+  sheet.getRange(nextRow, dateCol, items.length, 1).setValues(dates);
+  sheet.getRange(nextRow, priceCol, items.length, 1).setValues(prices);
+  sheet.getRange(nextRow, paidCol, items.length, 1).setValues(paid);
+}
+
+function getPersianDateTime() {
+  var parts = Utilities.formatDate(new Date(), 'Asia/Tehran', 'yyyy-M-d-HH:mm:ss').split('-');
+  var gYear = Number(parts[0]);
+  var gMonth = Number(parts[1]);
+  var gDay = Number(parts[2]);
+  var time = parts[3];
+  var j = gregorianToJalali(gYear, gMonth, gDay);
+  var jy = j[0];
+  var jm = ('0' + j[1]).slice(-2);
+  var jd = ('0' + j[2]).slice(-2);
+  return jy + '/' + jm + '/' + jd + ' ' + time;
+}
+
+function gregorianToJalali(gy, gm, gd) {
+  var g_d_m = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+  var jy;
+  if (gy > 1600) {
+    jy = 979;
+    gy -= 1600;
+  } else {
+    jy = 0;
+    gy -= 621;
+  }
+  var gy2 = gm > 2 ? gy + 1 : gy;
+  var days = (365 * gy) + Math.floor((gy2 + 3) / 4) - Math.floor((gy2 + 99) / 100) + Math.floor((gy2 + 399) / 400) - 80 + gd + g_d_m[gm - 1];
+  jy += 33 * Math.floor(days / 12053);
+  days %= 12053;
+  jy += 4 * Math.floor(days / 1461);
+  days %= 1461;
+  if (days > 365) {
+    jy += Math.floor((days - 1) / 365);
+    days = (days - 1) % 365;
+  }
+  var jm = (days < 186) ? 1 + Math.floor(days / 31) : 7 + Math.floor((days - 186) / 30);
+  var jd = 1 + ((days < 186) ? (days % 31) : ((days - 186) % 30));
+  return [jy, jm, jd];
+}

--- a/sale.html
+++ b/sale.html
@@ -516,10 +516,12 @@
         const price = Number(inventoryData.prices[idx]) || 0;
         const location = inventoryData.locations[idx] === 'STORE' ? 'مغازه' : inventoryData.locations[idx];
         const productName = inventoryData.names[idx];
+        const sku = inventoryData.skus ? inventoryData.skus[idx] : '';
         const inventoryCount = inventoryCounts[productName];
         const row = document.createElement('tr');
         row.dataset.serial = serial;
         row.dataset.productName = productName;
+        row.dataset.sku = sku;
         row.innerHTML =
             `<td class="row-number"></td>` +
             `<td>${productName}</td>` +
@@ -643,6 +645,37 @@
           }
         }
       });
+      const submitBtn = document.querySelector('#footer .submit');
+      submitBtn.addEventListener('click', function(){
+        const rows = Array.from(tbody.querySelectorAll('tr'));
+        if(!rows.length) return;
+        const items = rows.map(row => {
+          const price = parseNumber(row.querySelector('.price').textContent);
+          const discountInput = row.querySelector('.discount');
+          const paid = discountInput.value.trim() === '' ? price : parseNumber(discountInput.value);
+          return {
+            name: row.dataset.productName,
+            sku: row.dataset.sku || '',
+            serial: row.dataset.serial,
+            price: price,
+            paid: paid
+          };
+        });
+        google.script.run.withSuccessHandler(resetForm).submitOrder(items);
+      });
+
+      function resetForm(){
+        tbody.innerHTML = '';
+        addedSerials.clear();
+        manualFinalAmount = false;
+        finalAmountInput.value = '';
+        finalAmountReminder.style.display = 'none';
+        updateTotals();
+        updateRowNumbers();
+        updateInventoryDisplay();
+        snInput.value = '';
+        snInput.focus();
+      }
 
       setTimeout(() => snInput.focus(), 0);
     </script>


### PR DESCRIPTION
## Summary
- Implement `submitOrder` backend to generate order IDs, log product details, and convert timestamps to Jalali/Tehran time
- Store SKU on each row and transmit all sale rows on submit
- Reset the sales dialog instantly after registration for rapid entry

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a2790a26b883328082ec5f52ec0ecc