### PR TITLE
Generate sequential order IDs for sales

### DIFF
--- a/ProductSale.gs
+++ b/ProductSale.gs
@@ -35,9 +35,16 @@ function submitOrder(items) {
   var dateCol = ss.getRangeByName('OrderDate').getColumn();
   var priceCol = ss.getRangeByName('OrderPrice').getColumn();
   var paidCol = ss.getRangeByName('OrderPaidPrice').getColumn();
-  var nextRow = sheet.getLastRow() + 1;
-  var lastId = sheet.getRange(nextRow - 1, idCol).getValue();
-  var orderId = lastId ? Number(lastId) + 1 : 1;
+
+  var idValues = idRange.getValues().map(function(r){ return r[0]; });
+  var lastIndex = idValues.length - 1;
+  while (lastIndex >= 0 && !idValues[lastIndex]) {
+    lastIndex--;
+  }
+  var lastId = lastIndex >= 0 ? Number(idValues[lastIndex]) : 109;
+  var orderId = lastId + 1;
+  var nextRow = idRange.getRow() + lastIndex + 1;
+
   var ids = [], names = [], skus = [], sns = [], dates = [], prices = [], paid = [];
   var dateStr = getPersianDateTime();
   items.forEach(function(it) {


### PR DESCRIPTION
## Summary
- ensure submitOrder finds the last value in `OrderID` named range and increments from 110
- continue recording product SKUs from the dialog into the `OrderSKU` column

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a27c2f18988332b4418550999c8cc4