### PR TITLE
Handle invalid order IDs in product sale script

### DIFF
--- a/ProductSale.gs
+++ b/ProductSale.gs
@@ -38,10 +38,15 @@ function submitOrder(items) {
 
   var idValues = idRange.getValues().map(function(r){ return r[0]; });
   var lastIndex = idValues.length - 1;
-  while (lastIndex >= 0 && !idValues[lastIndex]) {
+  var lastId = 109;
+  while (lastIndex >= 0) {
+    var num = Number(idValues[lastIndex]);
+    if (!isNaN(num)) {
+      lastId = num;
+      break;
+    }
     lastIndex--;
   }
-  var lastId = lastIndex >= 0 ? Number(idValues[lastIndex]) : 109;
   var orderId = lastId + 1;
   var nextRow = idRange.getRow() + lastIndex + 1;
 

--- a/ProductSale.js
+++ b/ProductSale.js
@@ -38,10 +38,15 @@ function submitOrder(items) {
 
   var idValues = idRange.getValues().map(function(r){ return r[0]; });
   var lastIndex = idValues.length - 1;
-  while (lastIndex >= 0 && !idValues[lastIndex]) {
+  var lastId = 109;
+  while (lastIndex >= 0) {
+    var num = Number(idValues[lastIndex]);
+    if (!isNaN(num)) {
+      lastId = num;
+      break;
+    }
     lastIndex--;
   }
-  var lastId = lastIndex >= 0 ? Number(idValues[lastIndex]) : 109;
   var orderId = lastId + 1;
   var nextRow = idRange.getRow() + lastIndex + 1;
 


### PR DESCRIPTION
## Summary
- Prevent `#NUM!` errors by ignoring non-numeric values when determining the last order ID
- Apply fix to both `.gs` and `.js` versions of the product sale script

## Testing
- `node --check ProductSale.js`
- `node --check ProductSale.gs` *(fails: Unknown file extension)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_68a2809f6a4c83329d862966fdd3e727