### PR TITLE
Ensure sales data starts at first empty row

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,0 +1,21 @@
+/**
+ * Records an order in the first available row of the sales sheet.
+ *
+ * @param {Object[]} items - Array of sale items with name, sku, serial, price and paid fields.
+ */
+function submitOrder(items) {
+  if (!items || items.length === 0) return;
+
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = ss.getSheetByName('Sales') || ss.getSheets()[0];
+
+  const values = items.map(item => [item.name, item.sku, item.serial, item.price, item.paid]);
+
+  const startRow = sheet.getLastRow() + 1;
+  const neededRows = startRow + values.length - 1;
+  if (neededRows > sheet.getMaxRows()) {
+    sheet.insertRows(sheet.getMaxRows() + 1, neededRows - sheet.getMaxRows());
+  }
+
+  sheet.getRange(startRow, 1, values.length, values[0].length).setValues(values);
+}


### PR DESCRIPTION
## Summary
- Implement submitOrder() to write sales data to the first available row instead of appending beyond the sheet
- Automatically extend sheet if needed before writing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a34c6a4ec48332a6d090e59bd03d22