### PR TITLE
Adjust sales menu and record orders in first empty row

### DIFF
--- a/ProductSale.js
+++ b/ProductSale.js
@@ -1,7 +1,7 @@
 function onOpen() {
   var ui = SpreadsheetApp.getUi();
-  ui.createMenu('توسعه')
-    .addSubMenu(ui.createMenu('فروش').addItem('فروش محصول', 'showSaleDialog'))
+  ui.createMenu('فروش')
+    .addItem('خرده فروشی', 'showSaleDialog')
     .addToUi();
 }
 
@@ -37,18 +37,19 @@ function submitOrder(items) {
   var paidCol = ss.getRangeByName('OrderPaidPrice').getColumn();
 
   var idValues = idRange.getValues().map(function(r){ return r[0]; });
-  var lastIndex = idValues.length - 1;
   var lastId = 109;
-  while (lastIndex >= 0) {
-    var num = Number(idValues[lastIndex]);
-    if (!isNaN(num)) {
+  idValues.forEach(function(v){
+    var num = Number(v);
+    if (!isNaN(num) && num > lastId) {
       lastId = num;
-      break;
     }
-    lastIndex--;
-  }
+  });
   var orderId = lastId + 1;
-  var nextRow = idRange.getRow() + lastIndex + 1;
+  var nextIndex = 0;
+  while (nextIndex < idValues.length && idValues[nextIndex]) {
+    nextIndex++;
+  }
+  var nextRow = idRange.getRow() + nextIndex;
 
   var ids = [], names = [], skus = [], sns = [], dates = [], prices = [], paid = [];
   var dateStr = getPersianDateTime();


### PR DESCRIPTION
## Summary
- Make "فروش" the main menu with a "خرده فروشی" item that opens the sale dialog
- Insert orders at the first empty row to reuse gaps in the sheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a35b949890833286ab5e1874dc60cc