### PR TITLE
Auto-handle datalist selections in sale dialog

### DIFF
--- a/sale.html
+++ b/sale.html
@@ -617,32 +617,41 @@
         if(e.target === selectionModal) closeSelectionModal();
       });
 
+      function processQuery(query){
+        if(!query) return;
+        const idx = snIndex[query];
+        if(idx !== undefined){
+          addProduct(idx);
+          snInput.value = '';
+          snInput.focus();
+          return;
+        }
+        const persianIdx = persianSnIndex[query];
+        if(persianIdx !== undefined){
+          addProduct(persianIdx);
+          snInput.value = '';
+          snInput.focus();
+          return;
+        }
+        const indices = nameIndex[query.toLowerCase()];
+        if(indices){
+          const available = indices.filter(i => !addedSerials.has(inventoryData.sns[i]));
+          if(available.length){
+            openSelectionModal(available);
+          }
+          snInput.value = '';
+        }
+      }
+
+      snInput.addEventListener('input', function(e){
+        if(e.inputType === 'insertReplacementText'){
+          processQuery(snInput.value.trim());
+        }
+      });
+
       snInput.addEventListener('keydown', function(e){
         if(e.key === 'Enter'){
-          const query = snInput.value.trim();
-          if(!query) return;
-          const idx = snIndex[query];
-          if(idx !== undefined){
-            addProduct(idx);
-            snInput.value = '';
-            snInput.focus();
-            return;
-          }
-          const persianIdx = persianSnIndex[query];
-          if(persianIdx !== undefined){
-            addProduct(persianIdx);
-            snInput.value = '';
-            snInput.focus();
-            return;
-          }
-          const indices = nameIndex[query.toLowerCase()];
-          if(indices){
-            const available = indices.filter(i => !addedSerials.has(inventoryData.sns[i]));
-            if(available.length){
-              openSelectionModal(available);
-            }
-            snInput.value = '';
-          }
+          processQuery(snInput.value.trim());
         }
       });
       const submitBtn = document.querySelector('#footer .submit');


### PR DESCRIPTION
## Summary
- Automatically process product search when selecting from the datalist
- Refactor query handling into shared `processQuery` function

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open '/workspace/PosSheet/package.json')

------
https://chatgpt.com/codex/tasks/task_b_68a360ab91108332b08e02d6c1ceca66