### PR TITLE
Align cancel order date column left

### DIFF
--- a/cancel.html
+++ b/cancel.html
@@ -34,6 +34,9 @@
         padding:8px;
         text-align:center;
       }
+      td:nth-child(3) {
+        text-align:left;
+      }
       tr.selected {
         background:#ffe0e0;
       }


### PR DESCRIPTION
## Summary
- Left-align the date column in the cancel order dialog for clearer presentation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a3a44f45848332a9c9d558bd5ae669