### PR TITLE
Center date column text with LTR direction

### DIFF
--- a/cancel.html
+++ b/cancel.html
@@ -77,6 +77,10 @@
         color:#fff;
         cursor:pointer;
       }
+      td.date-cell {
+        direction: ltr;
+        text-align: center;
+      }
     </style>
   </head>
   <body>
@@ -167,6 +171,9 @@
               }
             } else {
               td.textContent = f;
+            }
+            if (idx === 1) {
+              td.classList.add('date-cell');
             }
             tr.appendChild(td);
           });


### PR DESCRIPTION
## Summary
- Center align date column text and force left-to-right direction in cancel dialog table

## Testing
- `node --check CancelOrder.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a3a629a68483328dd6a402df34d69a