### PR TITLE
feat: show Persian numerals in cancellation dates

### DIFF
--- a/cancel.html
+++ b/cancel.html
@@ -120,13 +120,17 @@
       function toEnglishDigits(str){
         return String(str).replace(/[۰-۹]/g, d => persianDigits.indexOf(d));
       }
+      function toPersianDigits(str){
+        return String(str).replace(/\d/g, d => persianDigits[d]);
+      }
       function formatDateStr(str){
         if(!str) return '';
         const d = new Date(str);
         if(isNaN(d)) return str;
         const pad = n => n.toString().padStart(2,'0');
-        return d.getFullYear() + '/' + pad(d.getMonth()+1) + '/' + pad(d.getDate()) + ' ' +
+        const formatted = d.getFullYear() + '/' + pad(d.getMonth()+1) + '/' + pad(d.getDate()) + ' ' +
                pad(d.getHours()) + ':' + pad(d.getMinutes()) + ':' + pad(d.getSeconds());
+        return toPersianDigits(formatted);
       }
 
       const allIndices = orderData.ids.map((_,i)=>i);


### PR DESCRIPTION
## Summary
- convert digits to Persian in cancellation dialog date column

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a3a74d0d7c8332998b0a6e50991d24