### PR TITLE
Handle order cancellation with inventory transfer

### DIFF
--- a/CancelOrder.js
+++ b/CancelOrder.js
@@ -2,22 +2,27 @@ function showCancelDialog() {
   var ss = SpreadsheetApp.getActive();
   var getValuesByName = function(name) {
     var range = ss.getRangeByName(name);
-    return range ? range.getValues().map(function(r){return r[0];}).filter(function(v,i){return v && i>0;}) : [];
+    return range ? range.getValues().map(function(r){return r[0];}) : [];
   };
+  var ids = getValuesByName('OrderID').slice(1).filter(String);
+  var len = ids.length;
+  var slice = function(arr){ return arr.slice(1, len + 1); };
   var orderData = {
-    ids: getValuesByName('OrderID'),
-    persianIds: getValuesByName('OrderPersianID'),
-    names: getValuesByName('OrderName'),
-    dates: getValuesByName('OrderDate'),
-    persianDates: getValuesByName('OrderPersianDate'),
-    sns: getValuesByName('OrderSN'),
-    persianSNS: getValuesByName('OrderPersianSN'),
-    prices: getValuesByName('OrderPrice'),
-    paidPrices: getValuesByName('OrderPaidPrice'),
-    skus: getValuesByName('OrderSKU'),
-    uniqueCodes: getValuesByName('OrderUniqueCode'),
-    sellers: getValuesByName('OrderSeller'),
-    locations: getValuesByName('OrderLocation')
+    ids: ids,
+    persianIds: slice(getValuesByName('OrderPersianID')),
+    names: slice(getValuesByName('OrderName')),
+    dates: slice(getValuesByName('OrderDate')),
+    persianDates: slice(getValuesByName('OrderPersianDate')),
+    sns: slice(getValuesByName('OrderSN')),
+    persianSNS: slice(getValuesByName('OrderPersianSN')),
+    prices: slice(getValuesByName('OrderPrice')),
+    paidPrices: slice(getValuesByName('OrderPaidPrice')),
+    skus: slice(getValuesByName('OrderSKU')),
+    uniqueCodes: slice(getValuesByName('OrderUniqueCode')),
+    sellers: slice(getValuesByName('OrderSeller')),
+    locations: slice(getValuesByName('OrderLocation')),
+    brands: slice(getValuesByName('OrderBrand')),
+    cancellations: slice(getValuesByName('OrderCancellation'))
   };
   var template = HtmlService.createTemplateFromFile('cancel');
   template.orderData = orderData;
@@ -27,17 +32,81 @@ function showCancelDialog() {
 
 function cancelOrders(orderIds) {
   if (!orderIds || !orderIds.length) return;
-  var ss = SpreadsheetApp.getActive();
-  var idRange = ss.getRangeByName('OrderID');
-  var sheet = idRange.getSheet();
-  var values = idRange.getValues().map(function(r){ return r[0]; });
-  var rowsToDelete = [];
+  var tlSs = SpreadsheetApp.openById('1LIR_q1xrpdzcqoBJmNXTO0UJ9dksoBjS7h3Me4PRB1s');
+  var getValues = function(ss, name){
+    return ss.getRangeByName(name).getValues().map(function(r){ return r[0]; });
+  };
+  var ids = getValues(tlSs, 'OrderID').slice(1);
+  var len = ids.length;
+  var skus = getValues(tlSs, 'OrderSKU').slice(1, len + 1);
+  var locations = getValues(tlSs, 'OrderLocation').slice(1, len + 1);
+  var names = getValues(tlSs, 'OrderName').slice(1, len + 1);
+  var prices = getValues(tlSs, 'OrderPrice').slice(1, len + 1);
+  var sellers = getValues(tlSs, 'OrderSeller').slice(1, len + 1);
+  var sns = getValues(tlSs, 'OrderSN').slice(1, len + 1);
+  var uniques = getValues(tlSs, 'OrderUniqueCode').slice(1, len + 1);
+  var brands = getValues(tlSs, 'OrderBrand').slice(1, len + 1);
+  var cancelRange = tlSs.getRangeByName('OrderCancellation');
+
   orderIds.forEach(function(id){
-    var idx = values.indexOf(id);
-    if (idx > -1) {
-      rowsToDelete.push(idRange.getRow() + idx);
+    var idx = ids.indexOf(id);
+    if (idx < 0) return;
+    var sku = skus[idx] || '';
+    if (sku.slice(0,2).toUpperCase() === 'BR') {
+      handleBR(sku);
+    } else if (sku.slice(0,2).toUpperCase() === 'TL') {
+      handleTL(idx);
     }
   });
-  rowsToDelete.sort(function(a,b){ return b - a; });
-  rowsToDelete.forEach(function(row){ sheet.deleteRow(row); });
+
+  function handleTL(idx){
+    cancelRange.getCell(idx + 2, 1).setValue(true);
+    appendToInventory(tlSs, {
+      location: locations[idx],
+      name: names[idx],
+      price: prices[idx],
+      seller: sellers[idx],
+      sku: skus[idx],
+      sn: sns[idx],
+      unique: uniques[idx],
+      brand: brands[idx]
+    }, false);
+  }
+
+  function handleBR(sku){
+    var brSs = SpreadsheetApp.openById('12-Khe_IZ9S7z_VN_LZQCHdcKEIgKDquviar8cSR_wG8');
+    var bSkus = getValues(brSs, 'StoreOrderSKU').slice(1);
+    var idx = bSkus.indexOf(sku);
+    if (idx < 0) return;
+    brSs.getRangeByName('StoreOrderCancellation').getCell(idx + 2, 1).setValue(true);
+    var data = {
+      location: brSs.getRangeByName('StoreOrderLocation').getCell(idx + 2, 1).getValue(),
+      name: brSs.getRangeByName('StoreOrderName').getCell(idx + 2, 1).getValue(),
+      price: brSs.getRangeByName('StoreOrderPrice').getCell(idx + 2, 1).getValue(),
+      seller: brSs.getRangeByName('StoreOrderSeller').getCell(idx + 2, 1).getValue(),
+      sku: sku,
+      sn: brSs.getRangeByName('StoreOrderSN').getCell(idx + 2, 1).getValue(),
+      unique: brSs.getRangeByName('StoreOrderUniqueCode').getCell(idx + 2, 1).getValue(),
+      brand: brSs.getRangeByName('StoreOrderBrand').getCell(idx + 2, 1).getValue()
+    };
+    appendToInventory(brSs, data, true);
+  }
+
+  function appendToInventory(ss, data, isStore){
+    var locRange = ss.getRangeByName('InventoryLocation');
+    var sheet = locRange.getSheet();
+    var row = sheet.getLastRow() + 1;
+    sheet.getRange(row, locRange.getColumn()).setValue(data.location);
+    sheet.getRange(row, ss.getRangeByName(isStore ? 'InventoryProductName' : 'InventoryName').getColumn()).setValue(data.name);
+    sheet.getRange(row, ss.getRangeByName('InventoryPrice').getColumn()).setValue(data.price);
+    sheet.getRange(row, ss.getRangeByName('InventorySupplier').getColumn()).setValue(data.seller);
+    sheet.getRange(row, ss.getRangeByName('InventorySKU').getColumn()).setValue(data.sku);
+    sheet.getRange(row, ss.getRangeByName('InventorySN').getColumn()).setValue(data.sn);
+    sheet.getRange(row, ss.getRangeByName('InventoryUniqueCode').getColumn()).setValue(data.unique);
+    sheet.getRange(row, ss.getRangeByName(isStore ? 'InventoryProductBrand' : 'InventoryBrand').getColumn()).setValue(data.brand);
+    var lblRange = ss.getRangeByName('InventoryLablePrinted');
+    var cell = sheet.getRange(row, lblRange.getColumn());
+    cell.insertCheckboxes();
+    cell.setValue(false);
+  }
 }

--- a/cancel.html
+++ b/cancel.html
@@ -40,6 +40,11 @@
       tr {
         cursor:pointer;
       }
+      tr.cancelled {
+        background:#e0e0e0;
+        color:#888;
+        cursor:default;
+      }
       .discount-info {
         font-size:12px;
         color:#d32f2f;
@@ -92,6 +97,7 @@
           <th>شماره سفارش</th>
           <th>تاریخ</th>
           <th>نام محصول</th>
+          <th>برند</th>
           <th>سریال</th>
           <th>قیمت محصول</th>
           <th>مبلغ پرداختی</th>
@@ -144,10 +150,6 @@
           const chk = document.createElement('input');
           chk.type = 'checkbox';
           chk.checked = selectedIds.has(orderData.ids[i]);
-          chk.addEventListener('click', e => {
-            e.stopPropagation();
-            toggle(orderData.ids[i], chk.checked, tr);
-          });
           chkTd.appendChild(chk);
           tr.appendChild(chkTd);
           const date = formatDateStr(orderData.persianDates[i] || orderData.dates[i] || '');
@@ -155,15 +157,16 @@
             orderData.ids[i],
             date,
             orderData.names[i],
+            orderData.brands[i],
             orderData.sns[i],
             orderData.prices[i],
             orderData.paidPrices[i]
           ];
           fields.forEach((f, idx) => {
             const td = document.createElement('td');
-            if (idx >= 4) {
+            if (idx >= 5) {
               td.textContent = formatNumber(f);
-              if (idx === 5) {
+              if (idx === 6) {
                 const diff = Number(orderData.prices[i]) - Number(orderData.paidPrices[i]);
                 if (diff > 0 && Number(orderData.prices[i])) {
                   const pct = Math.round(diff / Number(orderData.prices[i]) * 100);
@@ -181,17 +184,26 @@
             }
             tr.appendChild(td);
           });
-          tr.addEventListener('click', () => {
-            const checked = !chk.checked;
-            chk.checked = checked;
-            toggle(orderData.ids[i], checked, tr);
-            const search = document.getElementById('orderSearch');
-            if (search.value) {
-              search.value = '';
-              renderRows(allIndices);
-              search.focus();
-            }
-          });
+          if (!orderData.cancellations[i]) {
+            chk.addEventListener('click', e => {
+              e.stopPropagation();
+              toggle(orderData.ids[i], chk.checked, tr);
+            });
+            tr.addEventListener('click', () => {
+              const checked = !chk.checked;
+              chk.checked = checked;
+              toggle(orderData.ids[i], checked, tr);
+              const search = document.getElementById('orderSearch');
+              if (search.value) {
+                search.value = '';
+                renderRows(allIndices);
+                search.focus();
+              }
+            });
+          } else {
+            chk.disabled = true;
+            tr.classList.add('cancelled');
+          }
           tr.classList.toggle('selected', chk.checked);
           tbody.appendChild(tr);
         });
@@ -226,7 +238,7 @@
           const data = [
             orderData.ids[i], orderData.persianIds[i],
             orderData.sns[i], orderData.persianSNS[i],
-            name,
+            name, orderData.brands[i],
             date
           ].join(' ');
           const dataEn = toEnglishDigits(data);


### PR DESCRIPTION
## Summary
- Load order brand and cancellation status in the cancellation dialog
- Disable selection of canceled orders and show brand column
- Transfer canceled orders to inventory sheets and mark cancellation without deleting rows

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a3c24ee744833290b837816f0730bc