### PR TITLE
Hide brand column in cancel dialog

### DIFF
--- a/cancel.html
+++ b/cancel.html
@@ -97,7 +97,6 @@
           <th>شماره سفارش</th>
           <th>تاریخ</th>
           <th>نام محصول</th>
-          <th>برند</th>
           <th>سریال</th>
           <th>قیمت محصول</th>
           <th>مبلغ پرداختی</th>
@@ -157,16 +156,15 @@
             orderData.ids[i],
             date,
             orderData.names[i],
-            orderData.brands[i],
             orderData.sns[i],
             orderData.prices[i],
             orderData.paidPrices[i]
           ];
           fields.forEach((f, idx) => {
             const td = document.createElement('td');
-            if (idx >= 5) {
+            if (idx >= 4) {
               td.textContent = formatNumber(f);
-              if (idx === 6) {
+              if (idx === 5) {
                 const diff = Number(orderData.prices[i]) - Number(orderData.paidPrices[i]);
                 if (diff > 0 && Number(orderData.prices[i])) {
                   const pct = Math.round(diff / Number(orderData.prices[i]) * 100);


### PR DESCRIPTION
## Summary
- remove Brand column from cancellation dialog table
- adjust row rendering to skip brand while keeping price calculations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a3c579e238833296c0337ae3f2e61b