### PR TITLE
Refresh inventory data after sales and reopen sale dialog on cancellation

### DIFF
--- a/ProductSale.js
+++ b/ProductSale.js
@@ -7,6 +7,16 @@ function onOpen() {
 }
 
 function showSaleDialog() {
+  var data = getInventoryData();
+  var template = HtmlService.createTemplateFromFile('sale');
+  template.inventoryData = data;
+  var html = template.evaluate()
+    .setWidth(1200)
+    .setHeight(800);
+  SpreadsheetApp.getUi().showModalDialog(html, 'فروش محصول');
+}
+
+function getInventoryData() {
   var ss = SpreadsheetApp.getActive();
   var names = ss.getRangeByName('InventoryName').getValues().map(function(r){return r[0];}).filter(function(v,i){return v && i>0;});
   var sns = ss.getRangeByName('InventorySN').getValues().map(function(r){return r[0];}).filter(function(v,i){return v && i>0;});
@@ -17,12 +27,7 @@ function showSaleDialog() {
   var uniqueCodes = ss.getRangeByName('InventoryUniqueCode').getValues().map(function(r){return r[0];}).filter(function(v,i){return v && i>0;});
   var brands = ss.getRangeByName('InventoryBrand').getValues().map(function(r){return r[0];}).filter(function(v,i){return v && i>0;});
   var sellers = ss.getRangeByName('InventorySeller').getValues().map(function(r){return r[0];}).filter(function(v,i){return v && i>0;});
-  var template = HtmlService.createTemplateFromFile('sale');
-  template.inventoryData = {names:names, skus:skus, sns:sns, persianSNS:persianSns, locations:locations, prices:prices, uniqueCodes:uniqueCodes, brands:brands, sellers:sellers};
-  var html = template.evaluate()
-    .setWidth(1200)
-    .setHeight(800);
-  SpreadsheetApp.getUi().showModalDialog(html, 'فروش محصول');
+  return {names:names, skus:skus, sns:sns, persianSNS:persianSns, locations:locations, prices:prices, uniqueCodes:uniqueCodes, brands:brands, sellers:sellers};
 }
 
 function submitOrder(items) {

--- a/cancel.html
+++ b/cancel.html
@@ -252,7 +252,10 @@
 
       document.getElementById('cancelBtn').addEventListener('click', () => {
         const selected = Array.from(selectedIds);
-        google.script.run.withSuccessHandler(() => google.script.host.close()).cancelOrders(selected);
+        google.script.run.withSuccessHandler(() => {
+          google.script.host.close();
+          google.script.run.showSaleDialog();
+        }).cancelOrders(selected);
       });
     </script>
   </body>

--- a/sale.html
+++ b/sale.html
@@ -294,32 +294,40 @@
       <button class="submit">ثبت سفارش</button>
     </div>
     <script>
-      const inventoryData = <?!= JSON.stringify(inventoryData) ?>;
-      const snIndex = inventoryData.sns.reduce((o, sn, i) => (o[sn] = i, o), {});
-      const persianSnIndex = inventoryData.persianSNS.reduce((o, sn, i) => (o[sn] = i, o), {});
-      const nameIndex = inventoryData.names.reduce((o, name, i) => {
-        const key = name.toLowerCase();
-        (o[key] = o[key] || []).push(i);
-        return o;
-      }, {});
-      const inventoryCounts = inventoryData.names.reduce((o, name) => (o[name] = (o[name] || 0) + 1, o), {});
+      let inventoryData = <?!= JSON.stringify(inventoryData) ?>;
       const productList = document.getElementById('productList');
-      inventoryData.sns.forEach(sn => {
-        const opt = document.createElement('option');
-        opt.value = sn;
-        productList.appendChild(opt);
-      });
-      inventoryData.persianSNS.forEach(sn => {
-        const opt = document.createElement('option');
-        opt.value = sn;
-        productList.appendChild(opt);
-      });
-      const uniqueNames = Array.from(new Set(inventoryData.names));
-      uniqueNames.forEach(name => {
-        const opt = document.createElement('option');
-        opt.value = name;
-        productList.appendChild(opt);
-      });
+      let snIndex, persianSnIndex, nameIndex, inventoryCounts, uniqueNames;
+
+      function loadInventoryData(data){
+        inventoryData = data;
+        snIndex = inventoryData.sns.reduce((o, sn, i) => (o[sn] = i, o), {});
+        persianSnIndex = inventoryData.persianSNS.reduce((o, sn, i) => (o[sn] = i, o), {});
+        nameIndex = inventoryData.names.reduce((o, name, i) => {
+          const key = name.toLowerCase();
+          (o[key] = o[key] || []).push(i);
+          return o;
+        }, {});
+        inventoryCounts = inventoryData.names.reduce((o, name) => (o[name] = (o[name] || 0) + 1, o), {});
+        productList.innerHTML = '';
+        inventoryData.sns.forEach(sn => {
+          const opt = document.createElement('option');
+          opt.value = sn;
+          productList.appendChild(opt);
+        });
+        inventoryData.persianSNS.forEach(sn => {
+          const opt = document.createElement('option');
+          opt.value = sn;
+          productList.appendChild(opt);
+        });
+        uniqueNames = Array.from(new Set(inventoryData.names));
+        uniqueNames.forEach(name => {
+          const opt = document.createElement('option');
+          opt.value = name;
+          productList.appendChild(opt);
+        });
+      }
+
+      loadInventoryData(inventoryData);
       const snInput = document.querySelector('.sn');
       const tbody = document.querySelector('#productTable tbody');
       const totalEl = document.getElementById('total');
@@ -681,6 +689,9 @@
         updateInventoryDisplay();
         snInput.value = '';
         snInput.focus();
+        setTimeout(() => {
+          google.script.run.withSuccessHandler(loadInventoryData).getInventoryData();
+        }, 5000);
       }
 
       setTimeout(() => snInput.focus(), 0);


### PR DESCRIPTION
## Summary
- fetch inventory data via new `getInventoryData` function and reuse in sale dialog
- after cancelling orders, close the cancel dialog and open the sale dialog automatically
- refresh inventory ranges 5 seconds after submitting an order so dropdowns stay updated

## Testing
- `node --check ProductSale.js && echo "ProductSale.js syntax OK"`
- `node --check CancelOrder.js && echo "CancelOrder.js syntax OK"`
- `npm test` *(fails: Could not read package.json)*
- `npx htmlhint sale.html` *(interactive prompt, package not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68a3c990f82483328cf3db0a8e033ffd