### PR TITLE
Load sale dialog asynchronously

### DIFF
--- a/ProductSale.js
+++ b/ProductSale.js
@@ -7,10 +7,8 @@ function onOpen() {
 }
 
 function showSaleDialog() {
-  var data = getInventoryData();
-  var template = HtmlService.createTemplateFromFile('sale');
-  template.inventoryData = data;
-  var html = template.evaluate()
+  var html = HtmlService.createTemplateFromFile('sale')
+    .evaluate()
     .setWidth(1200)
     .setHeight(800);
   SpreadsheetApp.getUi().showModalDialog(html, 'فروش محصول');

--- a/sale.html
+++ b/sale.html
@@ -294,7 +294,7 @@
       <button class="submit">ثبت سفارش</button>
     </div>
     <script>
-      let inventoryData = <?!= JSON.stringify(inventoryData) ?>;
+      let inventoryData = {};
       const productList = document.getElementById('productList');
       let snIndex, persianSnIndex, nameIndex, inventoryCounts, uniqueNames;
 
@@ -327,7 +327,7 @@
         });
       }
 
-      loadInventoryData(inventoryData);
+      google.script.run.withSuccessHandler(loadInventoryData).getInventoryData();
       const snInput = document.querySelector('.sn');
       const tbody = document.querySelector('#productTable tbody');
       const totalEl = document.getElementById('total');


### PR DESCRIPTION
## Summary
- Simplify sale dialog loading by opening HTML first and fetching inventory data on demand
- Asynchronously populate inventory options after dialog opens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a469a133388332b18144822ff3157a