### PR TITLE
Improve sale dialog load performance

### DIFF
--- a/CancelOrder.js
+++ b/CancelOrder.js
@@ -106,4 +106,5 @@ function cancelOrders(orderIds) {
     cell.insertCheckboxes();
     cell.setValue(false);
   }
+  CacheService.getDocumentCache().remove('inventoryData');
 }

--- a/sale.html
+++ b/sale.html
@@ -294,7 +294,7 @@
       <button class="submit">ثبت سفارش</button>
     </div>
     <script>
-      let inventoryData = <?!= JSON.stringify(inventoryData) ?>;
+      let inventoryData = {};
       const productList = document.getElementById('productList');
       let snIndex, persianSnIndex, nameIndex, inventoryCounts, uniqueNames;
 
@@ -325,10 +325,13 @@
           opt.value = name;
           productList.appendChild(opt);
         });
+        snInput.disabled = false;
+        snInput.focus();
       }
 
-      loadInventoryData(inventoryData);
       const snInput = document.querySelector('.sn');
+      snInput.disabled = true;
+      google.script.run.withSuccessHandler(loadInventoryData).getInventoryData();
       const tbody = document.querySelector('#productTable tbody');
       const totalEl = document.getElementById('total');
       const finalAmountInput = document.getElementById('finalAmount');
@@ -693,8 +696,6 @@
           google.script.run.withSuccessHandler(loadInventoryData).getInventoryData();
         }, 5000);
       }
-
-      setTimeout(() => snInput.focus(), 0);
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Load sale dialog immediately and fetch inventory data asynchronously
- Cache inventory data server-side and invalidate cache after orders or cancellations

## Testing
- `node --check ProductSale.js`
- `node --check CancelOrder.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a46b03d8548332b7e773e3751d1ae5