### PR TITLE
Fix order ID incrementation

### DIFF
--- a/ProductSale.js
+++ b/ProductSale.js
@@ -108,7 +108,8 @@ function processExternalOrder(cfg, items, dateStr) {
   var sellerCol = sellerRange ? sellerRange.getColumn() : null;
   var brandCol = brandRange ? brandRange.getColumn() : null;
 
-  var idValues = idRange.getValues().map(function(r){ return r[0]; });
+  var idValuesRange = sheet.getRange(idRange.getRow(), idCol, sheet.getLastRow() - idRange.getRow() + 1, 1);
+  var idValues = idValuesRange.getValues().map(function(r){ return r[0]; });
   var lastId = 0;
   idValues.forEach(function(v){
     var num = Number(v);


### PR DESCRIPTION
## Summary
- ensure order ID increments by scanning entire ID column before assigning new order numbers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a46c88bf248332bd09e7f66caaa1ce