### PR TITLE
Fix total calculation and enable cancel order action

### DIFF
--- a/CancelOrder.js
+++ b/CancelOrder.js
@@ -4,7 +4,7 @@ function showCancelDialog() {
     var range = ss.getRangeByName(name);
     return range ? range.getValues().map(function(r){return r[0];}) : [];
   };
-  var ids = getValuesByName('OrderID').slice(1).filter(String);
+  var ids = getValuesByName('OrderID').slice(1).filter(String).map(String);
   var len = ids.length;
   var slice = function(arr){ return arr.slice(1, len + 1); };
   var orderData = {
@@ -32,11 +32,12 @@ function showCancelDialog() {
 
 function cancelOrders(orderIds) {
   if (!orderIds || !orderIds.length) return;
+  orderIds = orderIds.map(String);
   var tlSs = SpreadsheetApp.openById('1LIR_q1xrpdzcqoBJmNXTO0UJ9dksoBjS7h3Me4PRB1s');
   var getValues = function(ss, name){
     return ss.getRangeByName(name).getValues().map(function(r){ return r[0]; });
   };
-  var ids = getValues(tlSs, 'OrderID').slice(1);
+  var ids = getValues(tlSs, 'OrderID').slice(1).map(String);
   var len = ids.length;
   var skus = getValues(tlSs, 'OrderSKU').slice(1, len + 1);
   var locations = getValues(tlSs, 'OrderLocation').slice(1, len + 1);

--- a/cancel.html
+++ b/cancel.html
@@ -122,6 +122,9 @@
       function formatNumber(num){
         return Number(num || 0).toLocaleString('fa-IR').replace(/٬/g, ',');
       }
+      function parseNumber(str){
+        return Number(String(str).replace(/,/g, '').replace(/[۰-۹]/g, d => persianDigits.indexOf(d))) || 0;
+      }
       function toEnglishDigits(str){
         return String(str).replace(/[۰-۹]/g, d => persianDigits.indexOf(d));
       }
@@ -165,9 +168,11 @@
             if (idx >= 4) {
               td.textContent = formatNumber(f);
               if (idx === 5) {
-                const diff = Number(orderData.prices[i]) - Number(orderData.paidPrices[i]);
-                if (diff > 0 && Number(orderData.prices[i])) {
-                  const pct = Math.round(diff / Number(orderData.prices[i]) * 100);
+                const price = parseNumber(orderData.prices[i]);
+                const paid = parseNumber(orderData.paidPrices[i]);
+                const diff = price - paid;
+                if (diff > 0 && price) {
+                  const pct = Math.round(diff / price * 100);
                   const info = document.createElement('div');
                   info.className = 'discount-info';
                   info.textContent = '-' + formatNumber(diff) + ' (' + formatNumber(pct) + '%)';
@@ -222,7 +227,7 @@
         let sum = 0;
         selectedIds.forEach(id => {
           const i = idIndex[id];
-          sum += Number(orderData.paidPrices[i]) || 0;
+          sum += parseNumber(orderData.paidPrices[i]);
         });
         totalEl.textContent = formatNumber(sum);
       }
@@ -252,6 +257,7 @@
 
       document.getElementById('cancelBtn').addEventListener('click', () => {
         const selected = Array.from(selectedIds);
+        if (!selected.length) return;
         google.script.run.withSuccessHandler(() => {
           google.script.host.close();
           google.script.run.showSaleDialog();


### PR DESCRIPTION
## Summary
- parse numbers from Persian digits and commas on cancel order dialog
- convert order IDs to strings before server processing
- ignore cancel action when nothing selected

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a46ed8e4ac8332ac70c930b32dfd5e