### PR TITLE
Limit last row detection to relevant columns

### DIFF
--- a/CancelOrder.js
+++ b/CancelOrder.js
@@ -1,9 +1,25 @@
+function getLastRowInRange(sheet, startCol, endCol) {
+  var lastRow = sheet.getLastRow();
+  var values = sheet
+    .getRange(1, startCol, lastRow, endCol - startCol + 1)
+    .getValues();
+  for (var i = values.length - 1; i >= 0; i--) {
+    var row = values[i];
+    for (var j = 0; j < row.length; j++) {
+      if (row[j] !== '' && row[j] !== null) {
+        return i + 1;
+      }
+    }
+  }
+  return 0;
+}
+
 function showCancelDialog() {
   var ss = SpreadsheetApp.getActive();
   var baseRange = ss.getRangeByName('OrderID');
   if (!baseRange) return;
   var sheet = baseRange.getSheet();
-  var lastRow = sheet.getLastRow();
+  var lastRow = getLastRowInRange(sheet, 1, 4);
   var getValuesByName = function(name) {
     var range = ss.getRangeByName(name);
     if (!range) return [];
@@ -52,7 +68,7 @@ function cancelOrders(orderIds) {
     var sheetId = sheet.getSheetId();
     var lastRow = lastRows[sheetId];
     if (!lastRow) {
-      lastRow = sheet.getLastRow();
+      lastRow = getLastRowInRange(sheet, 1, 4);
       lastRows[sheetId] = lastRow;
     }
     var startRow = range.getRow() + 1;

--- a/ProductSale.js
+++ b/ProductSale.js
@@ -32,6 +32,22 @@ function getColumnValues(rangeName, sheet, lastRow) {
     .map(function(r){return r[0];});
 }
 
+function getLastRowInRange(sheet, startCol, endCol) {
+  var lastRow = sheet.getLastRow();
+  var values = sheet
+    .getRange(1, startCol, lastRow, endCol - startCol + 1)
+    .getValues();
+  for (var i = values.length - 1; i >= 0; i--) {
+    var row = values[i];
+    for (var j = 0; j < row.length; j++) {
+      if (row[j] !== '' && row[j] !== null) {
+        return i + 1;
+      }
+    }
+  }
+  return 0;
+}
+
 function getInventoryData() {
   var ss = SpreadsheetApp.getActive();
   var baseRange = ss.getRangeByName('InventoryName');
@@ -39,7 +55,7 @@ function getInventoryData() {
     return {names:[], skus:[], sns:[], persianSNS:[], locations:[], prices:[], uniqueCodes:[], brands:[], sellers:[]};
   }
   var sheet = baseRange.getSheet();
-  var lastRow = sheet.getLastRow();
+  var lastRow = getLastRowInRange(sheet, 1, 5);
   var names = getColumnValues('InventoryName', sheet, lastRow);
   var sns = getColumnValues('InventorySN', sheet, lastRow);
   var persianSns = getColumnValues('InventoryPersianSN', sheet, lastRow);


### PR DESCRIPTION
## Summary
- Avoid loading blank rows in cancel order dialog by computing last row from columns A-D
- Restrict last row lookup in inventory retrieval to columns A-E for the sale dialog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a483e704dc8332b94994476352fee0