### PR TITLE
Map store location to STORE in inventory

### DIFF
--- a/CancelOrder.js
+++ b/CancelOrder.js
@@ -213,7 +213,8 @@ function cancelOrders(orderIds) {
     var sheet = locRange.getSheet();
     var row = sheet.getLastRow() + 1;
     Logger.log('سطر جدید موجودی: %s', row);
-    sheet.getRange(row, locRange.getColumn()).setValue(data.location);
+    var locationValue = data.location === 'مغازه' ? 'STORE' : data.location;
+    sheet.getRange(row, locRange.getColumn()).setValue(locationValue);
     sheet.getRange(row, ss.getRangeByName(isStore ? 'InventoryProductName' : 'InventoryName').getColumn()).setValue(data.name);
     sheet.getRange(row, ss.getRangeByName('InventorySupplier').getColumn()).setValue(data.seller);
     sheet.getRange(row, ss.getRangeByName('InventorySKU').getColumn()).setValue(data.sku);


### PR DESCRIPTION
## Summary
- normalize store location to `STORE` when returning cancelled items to inventory

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a4d059776083328694e85a6c29846f