### PR TITLE
Fix cancel dialog handling of multiple selected orders

### DIFF
--- a/cancel.html
+++ b/cancel.html
@@ -114,7 +114,7 @@
       const orderData = <?!= JSON.stringify(orderData) ?>;
       const tbody = document.querySelector('#orderTable tbody');
       const totalEl = document.getElementById('total');
-      const selectedMap = new Map(); // sn -> sku
+      const selectedMap = new Map(); // (sn|sku) -> {sn, sku}
       const MAX_DISPLAY = 200;
       const persianDigits = '۰۱۲۳۴۵۶۷۸۹';
 
@@ -151,7 +151,8 @@
           const chkTd = document.createElement('td');
           const chk = document.createElement('input');
           chk.type = 'checkbox';
-          chk.checked = selectedMap.has(sn);
+          const key = sn + '|' + sku;
+          chk.checked = selectedMap.has(key);
           chkTd.appendChild(chk);
           tr.appendChild(chkTd);
           const date = formatDateStr(orderData.persianDates[i] || orderData.dates[i] || '');
@@ -213,10 +214,11 @@
 
       function toggle(sn, sku, checked, tr){
         tr.classList.toggle('selected', checked);
+        const key = sn + '|' + sku;
         if (checked) {
-          selectedMap.set(sn, sku);
+          selectedMap.set(key, { sn, sku });
         } else {
-          selectedMap.delete(sn);
+          selectedMap.delete(key);
         }
         updateTotal();
       }
@@ -254,8 +256,7 @@
       renderRows(allIndices);
 
       document.getElementById('cancelBtn').addEventListener('click', () => {
-        const selected = Array.from(selectedMap.entries())
-          .map(([sn, sku]) => ({ sn, sku }));
+        const selected = Array.from(selectedMap.values());
         google.script.run.withSuccessHandler(() => {
           google.script.host.close();
           google.script.run.showSaleDialog();


### PR DESCRIPTION
## Summary
- Track selected orders using SN and SKU combination to allow multiple selections
- Send all selected orders for cancellation

## Testing
- `node --check CancelOrder.js`


------
https://chatgpt.com/codex/tasks/task_b_68a703fae2dc8332b6b1f4f987f2af95