### PR TITLE
Add timing logs and stop auto sale dialog reopen

### DIFF
--- a/CancelOrder.js
+++ b/CancelOrder.js
@@ -1,3 +1,28 @@
+var global = this;
+
+function startTimer(name){
+  var start = Date.now();
+  return function(){
+    console.log(name + ' took ' + (Date.now() - start) + 'ms');
+  };
+}
+
+function addTiming(names){
+  names.forEach(function(name){
+    var fn = global[name];
+    if (typeof fn === 'function'){
+      global[name] = function(){
+        var end = startTimer(name);
+        try {
+          return fn.apply(this, arguments);
+        } finally {
+          end();
+        }
+      };
+    }
+  });
+}
+
 function getLastDataRow(range) {
   var sheet = range.getSheet();
   var startRow = range.getRow() + 1;
@@ -59,111 +84,133 @@ function showCancelDialog() {
 }
 
 function cancelOrders(items) {
-  if (!items || !items.length) {
-    return;
-  }
-  items = items.map(function(it){
-    return { sn: String(it.sn), sku: it.sku != null ? String(it.sku) : '' };
-  });
-  var tlSs = SpreadsheetApp.openById('1LIR_q1xrpdzcqoBJmNXTO0UJ9dksoBjS7h3Me4PRB1s');
-  var tlSnRange = tlSs.getRangeByName('OrderSN');
-  var brSs = SpreadsheetApp.openById('12-Khe_IZ9S7z_VN_LZQCHdcKEIgKDquviar8cSR_wG8');
-  var brSnRange = brSs.getRangeByName('StoreOrderSN');
-  var lastRows = {};
-  lastRows[tlSnRange.getSheet().getSheetId()] = getLastDataRow(tlSnRange);
-  lastRows[brSnRange.getSheet().getSheetId()] = getLastDataRow(brSnRange);
-  var getValues = function(ss, name){
-    var range = ss.getRangeByName(name);
-    if (!range) return [];
-    var sheet = range.getSheet();
-    var sheetId = sheet.getSheetId();
-    var lastRow = lastRows[sheetId];
-    var startRow = range.getRow() + 1;
-    var col = range.getColumn();
-    if (lastRow < startRow) return [];
-    return sheet
-      .getRange(startRow, col, lastRow - startRow + 1, 1)
-      .getValues()
-      .map(function(r){return r[0];});
-  };
-  var sns = getValues(tlSs, 'OrderSN').map(function(s){ return s != null ? String(s) : ''; });
-  var len = sns.length;
-  var skus = getValues(tlSs, 'OrderSKU').map(function(s){ return s != null ? String(s) : ''; }).slice(0, len);
-  var locations = getValues(tlSs, 'OrderLocation').slice(0, len);
-  var names = getValues(tlSs, 'OrderName').slice(0, len);
-  var sellers = getValues(tlSs, 'OrderSeller').slice(0, len);
-  var uniques = getValues(tlSs, 'OrderUniqueCode').slice(0, len);
-  var brands = getValues(tlSs, 'OrderBrand').slice(0, len);
-  var cancelRange = tlSs.getRangeByName('OrderCancellation');
+  var end = startTimer('cancelOrders');
+  try {
+    if (!items || !items.length) {
+      return;
+    }
+    items = items.map(function(it){
+      return { sn: String(it.sn), sku: it.sku != null ? String(it.sku) : '' };
+    });
+    var tlSs = SpreadsheetApp.openById('1LIR_q1xrpdzcqoBJmNXTO0UJ9dksoBjS7h3Me4PRB1s');
+    var tlSnRange = tlSs.getRangeByName('OrderSN');
+    var brSs = SpreadsheetApp.openById('12-Khe_IZ9S7z_VN_LZQCHdcKEIgKDquviar8cSR_wG8');
+    var brSnRange = brSs.getRangeByName('StoreOrderSN');
+    var lastRows = {};
+    lastRows[tlSnRange.getSheet().getSheetId()] = getLastDataRow(tlSnRange);
+    lastRows[brSnRange.getSheet().getSheetId()] = getLastDataRow(brSnRange);
+    var getValues = function(ss, name){
+      var range = ss.getRangeByName(name);
+      if (!range) return [];
+      var sheet = range.getSheet();
+      var sheetId = sheet.getSheetId();
+      var lastRow = lastRows[sheetId];
+      var startRow = range.getRow() + 1;
+      var col = range.getColumn();
+      if (lastRow < startRow) return [];
+      return sheet
+        .getRange(startRow, col, lastRow - startRow + 1, 1)
+        .getValues()
+        .map(function(r){return r[0];});
+    };
+    var sns = getValues(tlSs, 'OrderSN').map(function(s){ return s != null ? String(s) : ''; });
+    var len = sns.length;
+    var skus = getValues(tlSs, 'OrderSKU').map(function(s){ return s != null ? String(s) : ''; }).slice(0, len);
+    var locations = getValues(tlSs, 'OrderLocation').slice(0, len);
+    var names = getValues(tlSs, 'OrderName').slice(0, len);
+    var sellers = getValues(tlSs, 'OrderSeller').slice(0, len);
+    var uniques = getValues(tlSs, 'OrderUniqueCode').slice(0, len);
+    var brands = getValues(tlSs, 'OrderBrand').slice(0, len);
+    var cancelRange = tlSs.getRangeByName('OrderCancellation');
 
-  var brSns = getValues(brSs, 'StoreOrderSN').map(function(s){ return s != null ? String(s) : ''; });
-  var brSkus = getValues(brSs, 'StoreOrderSKU').map(function(s){ return s != null ? String(s) : ''; }).slice(0, brSns.length);
-  var brLocations = getValues(brSs, 'StoreOrderLocation').slice(0, brSns.length);
-  var brNames = getValues(brSs, 'StoreOrderName').slice(0, brSns.length);
-  var brSellers = getValues(brSs, 'StoreOrderSeller').slice(0, brSns.length);
-  var brUniques = getValues(brSs, 'StoreOrderUniqueCode').slice(0, brSns.length);
-  var brBrands = getValues(brSs, 'StoreOrderBrand').slice(0, brSns.length);
-  var brCancelRange = brSs.getRangeByName('StoreOrderCancellation');
+    var brSns = getValues(brSs, 'StoreOrderSN').map(function(s){ return s != null ? String(s) : ''; });
+    var brSkus = getValues(brSs, 'StoreOrderSKU').map(function(s){ return s != null ? String(s) : ''; }).slice(0, brSns.length);
+    var brLocations = getValues(brSs, 'StoreOrderLocation').slice(0, brSns.length);
+    var brNames = getValues(brSs, 'StoreOrderName').slice(0, brSns.length);
+    var brSellers = getValues(brSs, 'StoreOrderSeller').slice(0, brSns.length);
+    var brUniques = getValues(brSs, 'StoreOrderUniqueCode').slice(0, brSns.length);
+    var brBrands = getValues(brSs, 'StoreOrderBrand').slice(0, brSns.length);
+    var brCancelRange = brSs.getRangeByName('StoreOrderCancellation');
 
-  items.forEach(function(item){
-    var prefix = item.sku.slice(0,2).toUpperCase();
-    if (prefix === 'BR') {
-      var brIdx = brSns.indexOf(item.sn);
-      if (brIdx >= 0) {
-        handleBR(brIdx);
+    items.forEach(function(item){
+      var prefix = item.sku.slice(0,2).toUpperCase();
+      if (prefix === 'BR') {
+        var brIdx = brSns.indexOf(item.sn);
+        if (brIdx >= 0) {
+          handleBR(brIdx);
+        }
+      } else {
+        var idx = sns.indexOf(item.sn);
+        if (idx >= 0) {
+          handleTL(idx);
+        }
       }
-    } else {
-      var idx = sns.indexOf(item.sn);
-      if (idx >= 0) {
-        handleTL(idx);
+    });
+
+    function handleTL(idx){
+      var endTL = startTimer('handleTL');
+      try {
+        try { cancelRange.getCell(idx + 2, 1).setValue(true); } catch(e) {}
+        var data = {
+          location: locations[idx],
+          name: names[idx],
+          seller: sellers[idx],
+          sku: skus[idx],
+          sn: sns[idx],
+          unique: uniques[idx],
+          brand: brands[idx]
+        };
+        appendToInventory(tlSs, data, false);
+      } finally {
+        endTL();
       }
     }
-  });
 
-  function handleTL(idx){
-    try { cancelRange.getCell(idx + 2, 1).setValue(true); } catch(e) {}
-    var data = {
-      location: locations[idx],
-      name: names[idx],
-      seller: sellers[idx],
-      sku: skus[idx],
-      sn: sns[idx],
-      unique: uniques[idx],
-      brand: brands[idx]
-    };
-    appendToInventory(tlSs, data, false);
-  }
+    function handleBR(idx){
+      var endBR = startTimer('handleBR');
+      try {
+        if (idx < 0) return;
+        try { brCancelRange.getCell(idx + 2, 1).setValue(true); } catch(e) {}
+        var data = {
+          location: brLocations[idx],
+          name: brNames[idx],
+          seller: brSellers[idx],
+          sku: brSkus[idx],
+          sn: brSns[idx],
+          unique: brUniques[idx],
+          brand: brBrands[idx]
+        };
+        appendToInventory(brSs, data, true);
+      } finally {
+        endBR();
+      }
+    }
 
-  function handleBR(idx){
-    if (idx < 0) return;
-    try { brCancelRange.getCell(idx + 2, 1).setValue(true); } catch(e) {}
-    var data = {
-      location: brLocations[idx],
-      name: brNames[idx],
-      seller: brSellers[idx],
-      sku: brSkus[idx],
-      sn: brSns[idx],
-      unique: brUniques[idx],
-      brand: brBrands[idx]
-    };
-    appendToInventory(brSs, data, true);
-  }
-
-  function appendToInventory(ss, data, isStore){
-    var locRange = ss.getRangeByName('InventoryLocation');
-    var sheet = locRange.getSheet();
-    var row = sheet.getLastRow() + 1;
-    var locationValue = data.location === 'مغازه' ? 'STORE' : data.location;
-    sheet.getRange(row, locRange.getColumn()).setValue(locationValue);
-    sheet.getRange(row, ss.getRangeByName(isStore ? 'InventoryProductName' : 'InventoryName').getColumn()).setValue(data.name);
-    sheet.getRange(row, ss.getRangeByName('InventorySupplier').getColumn()).setValue(data.seller);
-    sheet.getRange(row, ss.getRangeByName('InventorySKU').getColumn()).setValue(data.sku);
-    sheet.getRange(row, ss.getRangeByName('InventorySN').getColumn()).setValue(data.sn);
-    sheet.getRange(row, ss.getRangeByName('InventoryUniqueCode').getColumn()).setValue(data.unique);
-    sheet.getRange(row, ss.getRangeByName(isStore ? 'InventoryProductBrand' : 'InventoryBrand').getColumn()).setValue(data.brand);
-    var lblRange = ss.getRangeByName('InventoryLablePrinted');
-    var cell = sheet.getRange(row, lblRange.getColumn());
-    cell.insertCheckboxes();
-    cell.setValue(false);
+    function appendToInventory(ss, data, isStore){
+      var endAI = startTimer('appendToInventory');
+      try {
+        var locRange = ss.getRangeByName('InventoryLocation');
+        var sheet = locRange.getSheet();
+        var row = sheet.getLastRow() + 1;
+        var locationValue = data.location === 'مغازه' ? 'STORE' : data.location;
+        sheet.getRange(row, locRange.getColumn()).setValue(locationValue);
+        sheet.getRange(row, ss.getRangeByName(isStore ? 'InventoryProductName' : 'InventoryName').getColumn()).setValue(data.name);
+        sheet.getRange(row, ss.getRangeByName('InventorySupplier').getColumn()).setValue(data.seller);
+        sheet.getRange(row, ss.getRangeByName('InventorySKU').getColumn()).setValue(data.sku);
+        sheet.getRange(row, ss.getRangeByName('InventorySN').getColumn()).setValue(data.sn);
+        sheet.getRange(row, ss.getRangeByName('InventoryUniqueCode').getColumn()).setValue(data.unique);
+        sheet.getRange(row, ss.getRangeByName(isStore ? 'InventoryProductBrand' : 'InventoryBrand').getColumn()).setValue(data.brand);
+        var lblRange = ss.getRangeByName('InventoryLablePrinted');
+        var cell = sheet.getRange(row, lblRange.getColumn());
+        cell.insertCheckboxes();
+        cell.setValue(false);
+      } finally {
+        endAI();
+      }
+    }
+  } finally {
+    end();
   }
 }
+
+addTiming(['getLastDataRow', 'showCancelDialog']);

--- a/ProductSale.js
+++ b/ProductSale.js
@@ -1,3 +1,28 @@
+var global = this;
+
+function startTimer(name){
+  var start = Date.now();
+  return function(){
+    console.log(name + ' took ' + (Date.now() - start) + 'ms');
+  };
+}
+
+function addTiming(names){
+  names.forEach(function(name){
+    var fn = global[name];
+    if (typeof fn === 'function'){
+      global[name] = function(){
+        var end = startTimer(name);
+        try {
+          return fn.apply(this, arguments);
+        } finally {
+          end();
+        }
+      };
+    }
+  });
+}
+
 function onOpen() {
   var ui = SpreadsheetApp.getUi();
   ui.createMenu('فروش')
@@ -236,3 +261,16 @@ function gregorianToJalali(gy, gm, gd) {
   var jd = 1 + ((days < 186) ? (days % 31) : ((days - 186) % 30));
   return [jy, jm, jd];
 }
+
+addTiming([
+  'onOpen',
+  'showSaleDialog',
+  'getColumnValues',
+  'getLastDataRow',
+  'getInventoryData',
+  'submitOrder',
+  'handleExternalOrders',
+  'processExternalOrder',
+  'getPersianDateTime',
+  'gregorianToJalali'
+]);

--- a/cancel.html
+++ b/cancel.html
@@ -118,6 +118,27 @@
       const MAX_DISPLAY = 200;
       const persianDigits = '۰۱۲۳۴۵۶۷۸۹';
 
+      function startTimer(name){
+        const start = performance.now();
+        return () => console.log(name + ' took ' + (performance.now() - start).toFixed(2) + 'ms');
+      }
+
+      function addTiming(names){
+        names.forEach(name => {
+          const fn = window[name];
+          if (typeof fn === 'function'){
+            window[name] = function(...args){
+              const end = startTimer(name);
+              try {
+                return fn.apply(this, args);
+              } finally {
+                end();
+              }
+            };
+          }
+        });
+      }
+
       function formatNumber(num){
         return Number(num || 0).toLocaleString('fa-IR').replace(/٬/g, ',');
       }
@@ -254,13 +275,16 @@
       renderRows(allIndices);
 
       document.getElementById('cancelBtn').addEventListener('click', () => {
+        const end = startTimer('cancelOrders');
         const selected = Array.from(selectedMap.entries())
           .map(([sn, sku]) => ({ sn, sku }));
         google.script.run.withSuccessHandler(() => {
+          end();
           google.script.host.close();
-          google.script.run.showSaleDialog();
         }).cancelOrders(selected);
       });
+
+      addTiming(['formatNumber','toEnglishDigits','toPersianDigits','formatDateStr','renderRows','toggle','updateTotal','filterOrders']);
     </script>
   </body>
 </html>

--- a/sale.html
+++ b/sale.html
@@ -344,6 +344,26 @@
       const modalProductInfo = document.getElementById('modalProductInfo');
 
       const persianDigits = '۰۱۲۳۴۵۶۷۸۹';
+      function startTimer(name){
+        const start = performance.now();
+        return () => console.log(name + ' took ' + (performance.now() - start).toFixed(2) + 'ms');
+      }
+
+      function addTiming(names){
+        names.forEach(name => {
+          const fn = window[name];
+          if (typeof fn === 'function'){
+            window[name] = function(...args){
+              const end = startTimer(name);
+              try {
+                return fn.apply(this, args);
+              } finally {
+                end();
+              }
+            };
+          }
+        });
+      }
       function formatNumber(num){
         return Number(num || 0).toLocaleString('fa-IR').replace(/٬/g, ',');
       }
@@ -657,6 +677,7 @@
       });
       const submitBtn = document.querySelector('#footer .submit');
       submitBtn.addEventListener('click', function(){
+        const end = startTimer('submitOrder');
         if(finalAmountInput.value.trim() !== '' && finalAmountReminder.style.display !== 'none'){
           const val = parseNumber(finalAmountInput.value);
           finalAmountInput.value = formatNumber(val);
@@ -681,7 +702,10 @@
             brand: row.dataset.brand || ''
           };
         });
-        google.script.run.withSuccessHandler(resetForm).submitOrder(items);
+        google.script.run.withSuccessHandler(() => {
+          end();
+          resetForm();
+        }).submitOrder(items);
       });
 
       function resetForm(){
@@ -701,6 +725,8 @@
       }
 
       setTimeout(() => snInput.focus(), 0);
+
+      addTiming(['loadInventoryData','formatNumber','parseNumber','toEnglishDigits','resetModalSearch','updateTotals','updateFinalDiscount','applyExtraDiscount','updateRowDiscount','updateRowNumbers','updateInventoryDisplay','addProduct','openSelectionModal','closeSelectionModal','resetForm']);
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- log execution time for sale and cancel operations on both server and client
- stop reopening the sale dialog after canceling orders

## Testing
- `node --check ProductSale.js`
- `node --check CancelOrder.js`


------
https://chatgpt.com/codex/tasks/task_b_68a70a3f9d0483329b8adcdff562e614