### PR TITLE
feat: add detailed timing logs

### DIFF
--- a/CancelOrder.js
+++ b/CancelOrder.js
@@ -7,6 +7,15 @@ function startTimer(name){
   };
 }
 
+function timeStep(name, fn){
+  var end = startTimer(name);
+  try {
+    return fn();
+  } finally {
+    end();
+  }
+}
+
 function addTiming(names){
   names.forEach(function(name){
     var fn = global[name];
@@ -30,7 +39,9 @@ function getLastDataRow(range) {
   var lastRow = sheet.getLastRow();
   var numRows = lastRow - range.getRow();
   if (numRows < 1) return range.getRow();
-  var values = sheet.getRange(startRow, col, numRows, 1).getValues();
+  var values = timeStep('getLastDataRow:getValues', function(){
+    return sheet.getRange(startRow, col, numRows, 1).getValues();
+  });
   for (var i = values.length - 1; i >= 0; i--) {
     var val = values[i][0];
     if (val !== '' && val !== null) {
@@ -92,26 +103,28 @@ function cancelOrders(items) {
     items = items.map(function(it){
       return { sn: String(it.sn), sku: it.sku != null ? String(it.sku) : '' };
     });
-    var tlSs = SpreadsheetApp.openById('1LIR_q1xrpdzcqoBJmNXTO0UJ9dksoBjS7h3Me4PRB1s');
-    var tlSnRange = tlSs.getRangeByName('OrderSN');
-    var brSs = SpreadsheetApp.openById('12-Khe_IZ9S7z_VN_LZQCHdcKEIgKDquviar8cSR_wG8');
-    var brSnRange = brSs.getRangeByName('StoreOrderSN');
+    var tlSs = timeStep('open:tlSs', function(){ return SpreadsheetApp.openById('1LIR_q1xrpdzcqoBJmNXTO0UJ9dksoBjS7h3Me4PRB1s'); });
+    var tlSnRange = timeStep('tlSs:getRangeByName:OrderSN', function(){ return tlSs.getRangeByName('OrderSN'); });
+    var brSs = timeStep('open:brSs', function(){ return SpreadsheetApp.openById('12-Khe_IZ9S7z_VN_LZQCHdcKEIgKDquviar8cSR_wG8'); });
+    var brSnRange = timeStep('brSs:getRangeByName:StoreOrderSN', function(){ return brSs.getRangeByName('StoreOrderSN'); });
     var lastRows = {};
     lastRows[tlSnRange.getSheet().getSheetId()] = getLastDataRow(tlSnRange);
     lastRows[brSnRange.getSheet().getSheetId()] = getLastDataRow(brSnRange);
     var getValues = function(ss, name){
-      var range = ss.getRangeByName(name);
-      if (!range) return [];
-      var sheet = range.getSheet();
-      var sheetId = sheet.getSheetId();
-      var lastRow = lastRows[sheetId];
-      var startRow = range.getRow() + 1;
-      var col = range.getColumn();
-      if (lastRow < startRow) return [];
-      return sheet
-        .getRange(startRow, col, lastRow - startRow + 1, 1)
-        .getValues()
-        .map(function(r){return r[0];});
+      return timeStep('getValues:' + name, function(){
+        var range = ss.getRangeByName(name);
+        if (!range) return [];
+        var sheet = range.getSheet();
+        var sheetId = sheet.getSheetId();
+        var lastRow = lastRows[sheetId];
+        var startRow = range.getRow() + 1;
+        var col = range.getColumn();
+        if (lastRow < startRow) return [];
+        return sheet
+          .getRange(startRow, col, lastRow - startRow + 1, 1)
+          .getValues()
+          .map(function(r){return r[0];});
+      });
     };
     var sns = getValues(tlSs, 'OrderSN').map(function(s){ return s != null ? String(s) : ''; });
     var len = sns.length;
@@ -147,15 +160,17 @@ function cancelOrders(items) {
       }
     });
 
-    function handleTL(idx){
-      var endTL = startTimer('handleTL');
-      try {
-        try { cancelRange.getCell(idx + 2, 1).setValue(true); } catch(e) {}
-        var data = {
-          location: locations[idx],
-          name: names[idx],
-          seller: sellers[idx],
-          sku: skus[idx],
+      function handleTL(idx){
+        var endTL = startTimer('handleTL');
+        try {
+          timeStep('handleTL:setCancel', function(){
+            try { cancelRange.getCell(idx + 2, 1).setValue(true); } catch(e) {}
+          });
+          var data = {
+            location: locations[idx],
+            name: names[idx],
+            seller: sellers[idx],
+            sku: skus[idx],
           sn: sns[idx],
           unique: uniques[idx],
           brand: brands[idx]
@@ -166,16 +181,18 @@ function cancelOrders(items) {
       }
     }
 
-    function handleBR(idx){
-      var endBR = startTimer('handleBR');
-      try {
-        if (idx < 0) return;
-        try { brCancelRange.getCell(idx + 2, 1).setValue(true); } catch(e) {}
-        var data = {
-          location: brLocations[idx],
-          name: brNames[idx],
-          seller: brSellers[idx],
-          sku: brSkus[idx],
+      function handleBR(idx){
+        var endBR = startTimer('handleBR');
+        try {
+          if (idx < 0) return;
+          timeStep('handleBR:setCancel', function(){
+            try { brCancelRange.getCell(idx + 2, 1).setValue(true); } catch(e) {}
+          });
+          var data = {
+            location: brLocations[idx],
+            name: brNames[idx],
+            seller: brSellers[idx],
+            sku: brSkus[idx],
           sn: brSns[idx],
           unique: brUniques[idx],
           brand: brBrands[idx]
@@ -186,28 +203,50 @@ function cancelOrders(items) {
       }
     }
 
-    function appendToInventory(ss, data, isStore){
-      var endAI = startTimer('appendToInventory');
-      try {
-        var locRange = ss.getRangeByName('InventoryLocation');
-        var sheet = locRange.getSheet();
-        var row = sheet.getLastRow() + 1;
-        var locationValue = data.location === 'مغازه' ? 'STORE' : data.location;
-        sheet.getRange(row, locRange.getColumn()).setValue(locationValue);
-        sheet.getRange(row, ss.getRangeByName(isStore ? 'InventoryProductName' : 'InventoryName').getColumn()).setValue(data.name);
-        sheet.getRange(row, ss.getRangeByName('InventorySupplier').getColumn()).setValue(data.seller);
-        sheet.getRange(row, ss.getRangeByName('InventorySKU').getColumn()).setValue(data.sku);
-        sheet.getRange(row, ss.getRangeByName('InventorySN').getColumn()).setValue(data.sn);
-        sheet.getRange(row, ss.getRangeByName('InventoryUniqueCode').getColumn()).setValue(data.unique);
-        sheet.getRange(row, ss.getRangeByName(isStore ? 'InventoryProductBrand' : 'InventoryBrand').getColumn()).setValue(data.brand);
-        var lblRange = ss.getRangeByName('InventoryLablePrinted');
-        var cell = sheet.getRange(row, lblRange.getColumn());
-        cell.insertCheckboxes();
-        cell.setValue(false);
-      } finally {
-        endAI();
+      function appendToInventory(ss, data, isStore){
+        var endAI = startTimer('appendToInventory');
+        try {
+          var locRange = timeStep('appendToInventory:getLocationRange', function(){
+            return ss.getRangeByName('InventoryLocation');
+          });
+          var sheet = timeStep('appendToInventory:getSheet', function(){
+            return locRange.getSheet();
+          });
+          var row = timeStep('appendToInventory:getLastRow', function(){
+            return sheet.getLastRow() + 1;
+          });
+          var locationValue = data.location === 'مغازه' ? 'STORE' : data.location;
+          timeStep('appendToInventory:setLocation', function(){
+            sheet.getRange(row, locRange.getColumn()).setValue(locationValue);
+          });
+          timeStep('appendToInventory:setName', function(){
+            sheet.getRange(row, ss.getRangeByName(isStore ? 'InventoryProductName' : 'InventoryName').getColumn()).setValue(data.name);
+          });
+          timeStep('appendToInventory:setSupplier', function(){
+            sheet.getRange(row, ss.getRangeByName('InventorySupplier').getColumn()).setValue(data.seller);
+          });
+          timeStep('appendToInventory:setSKU', function(){
+            sheet.getRange(row, ss.getRangeByName('InventorySKU').getColumn()).setValue(data.sku);
+          });
+          timeStep('appendToInventory:setSN', function(){
+            sheet.getRange(row, ss.getRangeByName('InventorySN').getColumn()).setValue(data.sn);
+          });
+          timeStep('appendToInventory:setUnique', function(){
+            sheet.getRange(row, ss.getRangeByName('InventoryUniqueCode').getColumn()).setValue(data.unique);
+          });
+          timeStep('appendToInventory:setBrand', function(){
+            sheet.getRange(row, ss.getRangeByName(isStore ? 'InventoryProductBrand' : 'InventoryBrand').getColumn()).setValue(data.brand);
+          });
+          timeStep('appendToInventory:insertLabel', function(){
+            var lblRange = ss.getRangeByName('InventoryLablePrinted');
+            var cell = sheet.getRange(row, lblRange.getColumn());
+            cell.insertCheckboxes();
+            cell.setValue(false);
+          });
+        } finally {
+          endAI();
+        }
       }
-    }
   } finally {
     end();
   }


### PR DESCRIPTION
## Summary
- add `timeStep` helper for granular timing
- instrument slow spreadsheet operations in `cancelOrders`
- log individual steps in inventory updates for more insight

## Testing
- `node -c CancelOrder.js`


------
https://chatgpt.com/codex/tasks/task_b_68a70def04f083328b9de5d8830c953d