### PR TITLE
Consolidate order range loading

### DIFF
--- a/CancelOrder.js
+++ b/CancelOrder.js
@@ -53,40 +53,55 @@ function getLastDataRow(range) {
 
 function showCancelDialog() {
   var ss = SpreadsheetApp.getActive();
-  var snRange = ss.getRangeByName('OrderSN');
-  if (!snRange) return;
-  var sheet = snRange.getSheet();
-  var lastRow = getLastDataRow(snRange);
-  var getValuesByName = function(name) {
+  var ordersRange = ss.getRangeByName('Orders');
+  if (!ordersRange) return;
+  var sheet = ordersRange.getSheet();
+  var snHeader = sheet.getRange(ordersRange.getRow(), ordersRange.getColumn() + 3);
+  var lastRow = getLastDataRow(snHeader);
+  var numRows = lastRow - ordersRange.getRow();
+  var values = numRows > 0 ? sheet.getRange(ordersRange.getRow() + 1, ordersRange.getColumn(), numRows, ordersRange.getNumColumns()).getValues() : [];
+  var ids = [], names = [], dates = [], sns = [], prices = [], paidPrices = [], skus = [], uniqueCodes = [], sellers = [], locations = [], brands = [], cancellations = [];
+  values.forEach(function(r){
+    ids.push(r[0]);
+    names.push(r[1]);
+    skus.push(r[2] != null ? String(r[2]) : '');
+    sns.push(r[3] != null ? String(r[3]) : '');
+    dates.push(r[4]);
+    prices.push(r[5]);
+    paidPrices.push(r[6]);
+    locations.push(r[7]);
+    sellers.push(r[8]);
+    brands.push(r[9]);
+    uniqueCodes.push(r[10]);
+    cancellations.push(r[11]);
+  });
+  var len = ids.length;
+  var getPersian = function(name){
     var range = ss.getRangeByName(name);
     if (!range) return [];
     var startRow = range.getRow() + 1;
-    var col = range.getColumn();
     if (lastRow < startRow) return [];
-    return sheet
-      .getRange(startRow, col, lastRow - startRow + 1, 1)
+    return sheet.getRange(startRow, range.getColumn(), lastRow - startRow + 1, 1)
       .getValues()
-      .map(function(r){return r[0];});
+      .map(function(r){ return r[0]; })
+      .slice(0, len);
   };
-  var ids = getValuesByName('OrderID');
-  var len = ids.length;
-  var slice = function(arr){ return arr.slice(0, len); };
   var orderData = {
     ids: ids,
-    persianIds: slice(getValuesByName('OrderPersianID')),
-    names: slice(getValuesByName('OrderName')),
-    dates: slice(getValuesByName('OrderDate')),
-    persianDates: slice(getValuesByName('OrderPersianDate')),
-    sns: slice(getValuesByName('OrderSN')).map(String),
-    persianSNS: slice(getValuesByName('OrderPersianSN')),
-    prices: slice(getValuesByName('OrderPrice')),
-    paidPrices: slice(getValuesByName('OrderPaidPrice')),
-    skus: slice(getValuesByName('OrderSKU')).map(function(s){return s != null ? String(s) : ''; }),
-    uniqueCodes: slice(getValuesByName('OrderUniqueCode')),
-    sellers: slice(getValuesByName('OrderSeller')),
-    locations: slice(getValuesByName('OrderLocation')),
-    brands: slice(getValuesByName('OrderBrand')),
-    cancellations: slice(getValuesByName('OrderCancellation'))
+    persianIds: getPersian('OrderPersianID'),
+    names: names,
+    dates: dates,
+    persianDates: getPersian('OrderPersianDate'),
+    sns: sns,
+    persianSNS: getPersian('OrderPersianSN'),
+    prices: prices,
+    paidPrices: paidPrices,
+    skus: skus,
+    uniqueCodes: uniqueCodes,
+    sellers: sellers,
+    locations: locations,
+    brands: brands,
+    cancellations: cancellations
   };
   var template = HtmlService.createTemplateFromFile('cancel');
   template.orderData = orderData;
@@ -104,46 +119,38 @@ function cancelOrders(items) {
       return { sn: String(it.sn), sku: it.sku != null ? String(it.sku) : '' };
     });
     var tlSs = timeStep('open:tlSs', function(){ return SpreadsheetApp.openById('1LIR_q1xrpdzcqoBJmNXTO0UJ9dksoBjS7h3Me4PRB1s'); });
-    var tlSnRange = timeStep('tlSs:getRangeByName:OrderSN', function(){ return tlSs.getRangeByName('OrderSN'); });
     var brSs = timeStep('open:brSs', function(){ return SpreadsheetApp.openById('12-Khe_IZ9S7z_VN_LZQCHdcKEIgKDquviar8cSR_wG8'); });
-    var brSnRange = timeStep('brSs:getRangeByName:StoreOrderSN', function(){ return brSs.getRangeByName('StoreOrderSN'); });
-    var lastRows = {};
-    lastRows[tlSnRange.getSheet().getSheetId()] = getLastDataRow(tlSnRange);
-    lastRows[brSnRange.getSheet().getSheetId()] = getLastDataRow(brSnRange);
-    var getValues = function(ss, name){
-      return timeStep('getValues:' + name, function(){
-        var range = ss.getRangeByName(name);
-        if (!range) return [];
-        var sheet = range.getSheet();
-        var sheetId = sheet.getSheetId();
-        var lastRow = lastRows[sheetId];
-        var startRow = range.getRow() + 1;
-        var col = range.getColumn();
-        if (lastRow < startRow) return [];
-        return sheet
-          .getRange(startRow, col, lastRow - startRow + 1, 1)
-          .getValues()
-          .map(function(r){return r[0];});
-      });
-    };
-    var sns = getValues(tlSs, 'OrderSN').map(function(s){ return s != null ? String(s) : ''; });
-    var len = sns.length;
-    var skus = getValues(tlSs, 'OrderSKU').map(function(s){ return s != null ? String(s) : ''; }).slice(0, len);
-    var locations = getValues(tlSs, 'OrderLocation').slice(0, len);
-    var names = getValues(tlSs, 'OrderName').slice(0, len);
-    var sellers = getValues(tlSs, 'OrderSeller').slice(0, len);
-    var uniques = getValues(tlSs, 'OrderUniqueCode').slice(0, len);
-    var brands = getValues(tlSs, 'OrderBrand').slice(0, len);
-    var cancelRange = tlSs.getRangeByName('OrderCancellation');
 
-    var brSns = getValues(brSs, 'StoreOrderSN').map(function(s){ return s != null ? String(s) : ''; });
-    var brSkus = getValues(brSs, 'StoreOrderSKU').map(function(s){ return s != null ? String(s) : ''; }).slice(0, brSns.length);
-    var brLocations = getValues(brSs, 'StoreOrderLocation').slice(0, brSns.length);
-    var brNames = getValues(brSs, 'StoreOrderName').slice(0, brSns.length);
-    var brSellers = getValues(brSs, 'StoreOrderSeller').slice(0, brSns.length);
-    var brUniques = getValues(brSs, 'StoreOrderUniqueCode').slice(0, brSns.length);
-    var brBrands = getValues(brSs, 'StoreOrderBrand').slice(0, brSns.length);
-    var brCancelRange = brSs.getRangeByName('StoreOrderCancellation');
+    var tlOrders = timeStep('tlSs:getRangeByName:Orders', function(){ return tlSs.getRangeByName('Orders'); });
+    var brOrders = timeStep('brSs:getRangeByName:StoreOrders', function(){ return brSs.getRangeByName('StoreOrders'); });
+
+    var tlSheet = tlOrders.getSheet();
+    var brSheet = brOrders.getSheet();
+    var tlStartRow = tlOrders.getRow();
+    var brStartRow = brOrders.getRow();
+    var tlLastRow = getLastDataRow(tlSheet.getRange(tlStartRow, tlOrders.getColumn() + 3));
+    var brLastRow = getLastDataRow(brSheet.getRange(brStartRow, brOrders.getColumn() + 3));
+
+    var tlValues = tlLastRow > tlStartRow ? tlSheet.getRange(tlStartRow + 1, tlOrders.getColumn(), tlLastRow - tlStartRow, tlOrders.getNumColumns()).getValues() : [];
+    var brValues = brLastRow > brStartRow ? brSheet.getRange(brStartRow + 1, brOrders.getColumn(), brLastRow - brStartRow, brOrders.getNumColumns()).getValues() : [];
+
+    var sns = tlValues.map(function(r){ return r[3] != null ? String(r[3]) : ''; });
+    var skus = tlValues.map(function(r){ return r[2] != null ? String(r[2]) : ''; });
+    var locations = tlValues.map(function(r){ return r[7]; });
+    var names = tlValues.map(function(r){ return r[1]; });
+    var sellers = tlValues.map(function(r){ return r[8]; });
+    var uniques = tlValues.map(function(r){ return r[10]; });
+    var brands = tlValues.map(function(r){ return r[9]; });
+    var cancelCol = tlOrders.getColumn() + 11;
+
+    var brSns = brValues.map(function(r){ return r[3] != null ? String(r[3]) : ''; });
+    var brSkus = brValues.map(function(r){ return r[2] != null ? String(r[2]) : ''; });
+    var brLocations = brValues.map(function(r){ return r[7]; });
+    var brNames = brValues.map(function(r){ return r[1]; });
+    var brSellers = brValues.map(function(r){ return r[8]; });
+    var brUniques = brValues.map(function(r){ return r[10]; });
+    var brBrands = brValues.map(function(r){ return r[9]; });
+    var brCancelCol = brOrders.getColumn() + 11;
 
     items.forEach(function(item){
       var prefix = item.sku.slice(0,2).toUpperCase();
@@ -164,44 +171,44 @@ function cancelOrders(items) {
         var endTL = startTimer('handleTL');
         try {
           timeStep('handleTL:setCancel', function(){
-            try { cancelRange.getCell(idx + 2, 1).setValue(true); } catch(e) {}
+            try { tlSheet.getRange(tlStartRow + idx + 1, cancelCol).setValue(true); } catch(e) {}
           });
           var data = {
             location: locations[idx],
             name: names[idx],
             seller: sellers[idx],
             sku: skus[idx],
-          sn: sns[idx],
-          unique: uniques[idx],
-          brand: brands[idx]
-        };
-        appendToInventory(tlSs, data, false);
-      } finally {
-        endTL();
+            sn: sns[idx],
+            unique: uniques[idx],
+            brand: brands[idx]
+          };
+          appendToInventory(tlSs, data, false);
+        } finally {
+          endTL();
+        }
       }
-    }
 
       function handleBR(idx){
         var endBR = startTimer('handleBR');
         try {
           if (idx < 0) return;
           timeStep('handleBR:setCancel', function(){
-            try { brCancelRange.getCell(idx + 2, 1).setValue(true); } catch(e) {}
+            try { brSheet.getRange(brStartRow + idx + 1, brCancelCol).setValue(true); } catch(e) {}
           });
           var data = {
             location: brLocations[idx],
             name: brNames[idx],
             seller: brSellers[idx],
             sku: brSkus[idx],
-          sn: brSns[idx],
-          unique: brUniques[idx],
-          brand: brBrands[idx]
-        };
-        appendToInventory(brSs, data, true);
-      } finally {
-        endBR();
+            sn: brSns[idx],
+            unique: brUniques[idx],
+            brand: brBrands[idx]
+          };
+          appendToInventory(brSs, data, true);
+        } finally {
+          endBR();
+        }
       }
-    }
 
       function appendToInventory(ss, data, isStore){
         var endAI = startTimer('appendToInventory');

--- a/ProductSale.js
+++ b/ProductSale.js
@@ -99,66 +99,40 @@ function handleExternalOrders(dateStr, items) {
   if (tlItems.length) {
     processExternalOrder({
       spreadsheetId: '1LIR_q1xrpdzcqoBJmNXTO0UJ9dksoBjS7h3Me4PRB1s',
-      rangeNames: {
-        id: 'OrderID',
-        name: 'OrderName',
-        sku: 'OrderSKU',
-        sn: 'OrderSN',
-        date: 'OrderDate',
-        price: 'OrderPrice',
-        paid: 'OrderPaidPrice',
-        uniqueCode: 'OrderUniqueCode',
-        location: 'OrderLocation',
-        seller: 'OrderSeller',
-        brand: 'OrderBrand'
-      },
-        inventoryRange: 'Inventory'
+      rangeName: 'Orders',
+      inventoryRange: 'Inventory'
     }, tlItems, dateStr);
   }
   var brItems = items.filter(function(it){ return it.sku && it.sku.indexOf('BR') === 0; });
   if (brItems.length) {
     processExternalOrder({
       spreadsheetId: '12-Khe_IZ9S7z_VN_LZQCHdcKEIgKDquviar8cSR_wG8',
-      rangeNames: {
-        id: 'StoreOrderID',
-        name: 'StoreOrderName',
-        sku: 'StoreOrderSKU',
-        sn: 'StoreOrderSN',
-        date: 'StoreOrderDate',
-        price: 'StoreOrderPrice',
-        paid: 'StoreOrderPaidPrice',
-        uniqueCode: 'StoreOrderUniqueCode',
-        location: 'StoreOrderLocation',
-        seller: 'StoreOrderSeller',
-        brand: 'StoreOrderBrand'
-      },
-        inventoryRange: 'Inventory'
+      rangeName: 'StoreOrders',
+      inventoryRange: 'Inventory'
     }, brItems, dateStr);
   }
 }
 
 function processExternalOrder(cfg, items, dateStr) {
   var ss = SpreadsheetApp.openById(cfg.spreadsheetId);
-  var idRange = ss.getRangeByName(cfg.rangeNames.id);
-  if (!idRange) return;
-  var sheet = idRange.getSheet();
-  var idCol = idRange.getColumn();
-  var nameCol = ss.getRangeByName(cfg.rangeNames.name).getColumn();
-  var skuCol = ss.getRangeByName(cfg.rangeNames.sku).getColumn();
-  var snCol = ss.getRangeByName(cfg.rangeNames.sn).getColumn();
-  var dateCol = ss.getRangeByName(cfg.rangeNames.date).getColumn();
-  var priceCol = ss.getRangeByName(cfg.rangeNames.price).getColumn();
-  var paidCol = ss.getRangeByName(cfg.rangeNames.paid).getColumn();
-  var uniqueCodeRange = ss.getRangeByName(cfg.rangeNames.uniqueCode);
-  var locationRange = ss.getRangeByName(cfg.rangeNames.location);
-  var sellerRange = ss.getRangeByName(cfg.rangeNames.seller);
-  var brandRange = ss.getRangeByName(cfg.rangeNames.brand);
-  var uniqueCodeCol = uniqueCodeRange ? uniqueCodeRange.getColumn() : null;
-  var locationCol = locationRange ? locationRange.getColumn() : null;
-  var sellerCol = sellerRange ? sellerRange.getColumn() : null;
-  var brandCol = brandRange ? brandRange.getColumn() : null;
+  var baseRange = ss.getRangeByName(cfg.rangeName);
+  if (!baseRange) return;
+  var sheet = baseRange.getSheet();
+  var baseCol = baseRange.getColumn();
+  var startRow = baseRange.getRow();
+  var idCol = baseCol + 0;
+  var nameCol = baseCol + 1;
+  var skuCol = baseCol + 2;
+  var snCol = baseCol + 3;
+  var dateCol = baseCol + 4;
+  var priceCol = baseCol + 5;
+  var paidCol = baseCol + 6;
+  var locationCol = baseCol + 7;
+  var sellerCol = baseCol + 8;
+  var brandCol = baseCol + 9;
+  var uniqueCodeCol = baseCol + 10;
 
-  var idValuesRange = sheet.getRange(idRange.getRow(), idCol, sheet.getLastRow() - idRange.getRow() + 1, 1);
+  var idValuesRange = sheet.getRange(startRow, idCol, sheet.getLastRow() - startRow + 1, 1);
   var idValues = idValuesRange.getValues().map(function(r){ return r[0]; });
   var lastId = 0;
   idValues.forEach(function(v){
@@ -172,7 +146,7 @@ function processExternalOrder(cfg, items, dateStr) {
   while (nextIndex < idValues.length && idValues[nextIndex]) {
     nextIndex++;
   }
-  var nextRow = idRange.getRow() + nextIndex;
+  var nextRow = startRow + nextIndex;
 
   var ids = [], names = [], skus = [], sns = [], dates = [], prices = [], paid = [], uniqueCodes = [], locations = [], sellers = [], brands = [];
   items.forEach(function(it) {
@@ -195,10 +169,10 @@ function processExternalOrder(cfg, items, dateStr) {
   sheet.getRange(nextRow, dateCol, items.length, 1).setValues(dates);
   sheet.getRange(nextRow, priceCol, items.length, 1).setValues(prices);
   sheet.getRange(nextRow, paidCol, items.length, 1).setValues(paid);
-  if (uniqueCodeCol) sheet.getRange(nextRow, uniqueCodeCol, items.length, 1).setValues(uniqueCodes);
-  if (locationCol) sheet.getRange(nextRow, locationCol, items.length, 1).setValues(locations);
-  if (sellerCol) sheet.getRange(nextRow, sellerCol, items.length, 1).setValues(sellers);
-  if (brandCol) sheet.getRange(nextRow, brandCol, items.length, 1).setValues(brands);
+  sheet.getRange(nextRow, locationCol, items.length, 1).setValues(locations);
+  sheet.getRange(nextRow, sellerCol, items.length, 1).setValues(sellers);
+  sheet.getRange(nextRow, brandCol, items.length, 1).setValues(brands);
+  sheet.getRange(nextRow, uniqueCodeCol, items.length, 1).setValues(uniqueCodes);
 
   var invRange = ss.getRangeByName(cfg.inventoryRange);
   var invSheet = invRange ? invRange.getSheet() : null;


### PR DESCRIPTION
## Summary
- Replace per-column named range lookups with combined `Orders` and `StoreOrders` ranges
- Simplify cancel and submit dialogs by indexing into unified ranges

## Testing
- `node --check CancelOrder.js`
- `node --check ProductSale.js`


------
https://chatgpt.com/codex/tasks/task_b_68a7889bba488332b188d09daec86ecb