### PR TITLE
Use unified order ranges for external sheets

### DIFF
--- a/CancelOrder.js
+++ b/CancelOrder.js
@@ -104,21 +104,20 @@ function cancelOrders(items) {
       return { sn: String(it.sn), sku: it.sku != null ? String(it.sku) : '' };
     });
     var tlSs = timeStep('open:tlSs', function(){ return SpreadsheetApp.openById('1LIR_q1xrpdzcqoBJmNXTO0UJ9dksoBjS7h3Me4PRB1s'); });
-    var tlSnRange = timeStep('tlSs:getRangeByName:OrderSN', function(){ return tlSs.getRangeByName('OrderSN'); });
+    var tlOrders = timeStep('tlSs:getRangeByName:Orders', function(){ return tlSs.getRangeByName('Orders'); });
     var brSs = timeStep('open:brSs', function(){ return SpreadsheetApp.openById('12-Khe_IZ9S7z_VN_LZQCHdcKEIgKDquviar8cSR_wG8'); });
-    var brSnRange = timeStep('brSs:getRangeByName:StoreOrderSN', function(){ return brSs.getRangeByName('StoreOrderSN'); });
+    var brOrders = timeStep('brSs:getRangeByName:StoreOrders', function(){ return brSs.getRangeByName('StoreOrders'); });
     var lastRows = {};
-    lastRows[tlSnRange.getSheet().getSheetId()] = getLastDataRow(tlSnRange);
-    lastRows[brSnRange.getSheet().getSheetId()] = getLastDataRow(brSnRange);
-    var getValues = function(ss, name){
-      return timeStep('getValues:' + name, function(){
-        var range = ss.getRangeByName(name);
+    lastRows[tlOrders.getSheet().getSheetId()] = getLastDataRow(tlOrders.offset(0,3,tlOrders.getNumRows(),1));
+    lastRows[brOrders.getSheet().getSheetId()] = getLastDataRow(brOrders.offset(0,3,brOrders.getNumRows(),1));
+    var getValues = function(range, idx){
+      return timeStep('getValues:idx' + idx, function(){
         if (!range) return [];
         var sheet = range.getSheet();
         var sheetId = sheet.getSheetId();
         var lastRow = lastRows[sheetId];
         var startRow = range.getRow() + 1;
-        var col = range.getColumn();
+        var col = range.getColumn() + idx;
         if (lastRow < startRow) return [];
         return sheet
           .getRange(startRow, col, lastRow - startRow + 1, 1)
@@ -126,24 +125,24 @@ function cancelOrders(items) {
           .map(function(r){return r[0];});
       });
     };
-    var sns = getValues(tlSs, 'OrderSN').map(function(s){ return s != null ? String(s) : ''; });
+    var sns = getValues(tlOrders, 3).map(function(s){ return s != null ? String(s) : ''; });
     var len = sns.length;
-    var skus = getValues(tlSs, 'OrderSKU').map(function(s){ return s != null ? String(s) : ''; }).slice(0, len);
-    var locations = getValues(tlSs, 'OrderLocation').slice(0, len);
-    var names = getValues(tlSs, 'OrderName').slice(0, len);
-    var sellers = getValues(tlSs, 'OrderSeller').slice(0, len);
-    var uniques = getValues(tlSs, 'OrderUniqueCode').slice(0, len);
-    var brands = getValues(tlSs, 'OrderBrand').slice(0, len);
-    var cancelRange = tlSs.getRangeByName('OrderCancellation');
+    var skus = getValues(tlOrders, 2).map(function(s){ return s != null ? String(s) : ''; }).slice(0, len);
+    var locations = getValues(tlOrders, 7).slice(0, len);
+    var names = getValues(tlOrders, 1).slice(0, len);
+    var sellers = getValues(tlOrders, 8).slice(0, len);
+    var uniques = getValues(tlOrders, 10).slice(0, len);
+    var brands = getValues(tlOrders, 9).slice(0, len);
+    var cancelRange = tlOrders.offset(0,11,tlOrders.getNumRows(),1);
 
-    var brSns = getValues(brSs, 'StoreOrderSN').map(function(s){ return s != null ? String(s) : ''; });
-    var brSkus = getValues(brSs, 'StoreOrderSKU').map(function(s){ return s != null ? String(s) : ''; }).slice(0, brSns.length);
-    var brLocations = getValues(brSs, 'StoreOrderLocation').slice(0, brSns.length);
-    var brNames = getValues(brSs, 'StoreOrderName').slice(0, brSns.length);
-    var brSellers = getValues(brSs, 'StoreOrderSeller').slice(0, brSns.length);
-    var brUniques = getValues(brSs, 'StoreOrderUniqueCode').slice(0, brSns.length);
-    var brBrands = getValues(brSs, 'StoreOrderBrand').slice(0, brSns.length);
-    var brCancelRange = brSs.getRangeByName('StoreOrderCancellation');
+    var brSns = getValues(brOrders, 3).map(function(s){ return s != null ? String(s) : ''; });
+    var brSkus = getValues(brOrders, 2).map(function(s){ return s != null ? String(s) : ''; }).slice(0, brSns.length);
+    var brLocations = getValues(brOrders, 7).slice(0, brSns.length);
+    var brNames = getValues(brOrders, 1).slice(0, brSns.length);
+    var brSellers = getValues(brOrders, 8).slice(0, brSns.length);
+    var brUniques = getValues(brOrders, 10).slice(0, brSns.length);
+    var brBrands = getValues(brOrders, 9).slice(0, brSns.length);
+    var brCancelRange = brOrders.offset(0,11,brOrders.getNumRows(),1);
 
     items.forEach(function(item){
       var prefix = item.sku.slice(0,2).toUpperCase();

--- a/ProductSale.js
+++ b/ProductSale.js
@@ -99,66 +99,42 @@ function handleExternalOrders(dateStr, items) {
   if (tlItems.length) {
     processExternalOrder({
       spreadsheetId: '1LIR_q1xrpdzcqoBJmNXTO0UJ9dksoBjS7h3Me4PRB1s',
-      rangeNames: {
-        id: 'OrderID',
-        name: 'OrderName',
-        sku: 'OrderSKU',
-        sn: 'OrderSN',
-        date: 'OrderDate',
-        price: 'OrderPrice',
-        paid: 'OrderPaidPrice',
-        uniqueCode: 'OrderUniqueCode',
-        location: 'OrderLocation',
-        seller: 'OrderSeller',
-        brand: 'OrderBrand'
-      },
-        inventoryRange: 'Inventory'
+      ordersRange: 'Orders',
+      inventoryRange: 'Inventory'
     }, tlItems, dateStr);
   }
   var brItems = items.filter(function(it){ return it.sku && it.sku.indexOf('BR') === 0; });
   if (brItems.length) {
     processExternalOrder({
       spreadsheetId: '12-Khe_IZ9S7z_VN_LZQCHdcKEIgKDquviar8cSR_wG8',
-      rangeNames: {
-        id: 'StoreOrderID',
-        name: 'StoreOrderName',
-        sku: 'StoreOrderSKU',
-        sn: 'StoreOrderSN',
-        date: 'StoreOrderDate',
-        price: 'StoreOrderPrice',
-        paid: 'StoreOrderPaidPrice',
-        uniqueCode: 'StoreOrderUniqueCode',
-        location: 'StoreOrderLocation',
-        seller: 'StoreOrderSeller',
-        brand: 'StoreOrderBrand'
-      },
-        inventoryRange: 'Inventory'
+      ordersRange: 'StoreOrders',
+      inventoryRange: 'Inventory'
     }, brItems, dateStr);
   }
 }
 
 function processExternalOrder(cfg, items, dateStr) {
   var ss = SpreadsheetApp.openById(cfg.spreadsheetId);
-  var idRange = ss.getRangeByName(cfg.rangeNames.id);
-  if (!idRange) return;
-  var sheet = idRange.getSheet();
-  var idCol = idRange.getColumn();
-  var nameCol = ss.getRangeByName(cfg.rangeNames.name).getColumn();
-  var skuCol = ss.getRangeByName(cfg.rangeNames.sku).getColumn();
-  var snCol = ss.getRangeByName(cfg.rangeNames.sn).getColumn();
-  var dateCol = ss.getRangeByName(cfg.rangeNames.date).getColumn();
-  var priceCol = ss.getRangeByName(cfg.rangeNames.price).getColumn();
-  var paidCol = ss.getRangeByName(cfg.rangeNames.paid).getColumn();
-  var uniqueCodeRange = ss.getRangeByName(cfg.rangeNames.uniqueCode);
-  var locationRange = ss.getRangeByName(cfg.rangeNames.location);
-  var sellerRange = ss.getRangeByName(cfg.rangeNames.seller);
-  var brandRange = ss.getRangeByName(cfg.rangeNames.brand);
-  var uniqueCodeCol = uniqueCodeRange ? uniqueCodeRange.getColumn() : null;
-  var locationCol = locationRange ? locationRange.getColumn() : null;
-  var sellerCol = sellerRange ? sellerRange.getColumn() : null;
-  var brandCol = brandRange ? brandRange.getColumn() : null;
+  var ordersRange = ss.getRangeByName(cfg.ordersRange);
+  if (!ordersRange) return;
+  var sheet = ordersRange.getSheet();
+  var baseCol = ordersRange.getColumn();
+  var numCols = ordersRange.getNumColumns();
+  var col = function(idx){ return numCols > idx ? baseCol + idx : null; };
+  var idCol = col(0);
+  var nameCol = col(1);
+  var skuCol = col(2);
+  var snCol = col(3);
+  var dateCol = col(4);
+  var priceCol = col(5);
+  var paidCol = col(6);
+  var locationCol = col(7);
+  var sellerCol = col(8);
+  var brandCol = col(9);
+  var uniqueCodeCol = col(10);
 
-  var idValuesRange = sheet.getRange(idRange.getRow(), idCol, sheet.getLastRow() - idRange.getRow() + 1, 1);
+  var headerRow = ordersRange.getRow();
+  var idValuesRange = sheet.getRange(headerRow, idCol, sheet.getLastRow() - headerRow + 1, 1);
   var idValues = idValuesRange.getValues().map(function(r){ return r[0]; });
   var lastId = 0;
   idValues.forEach(function(v){
@@ -172,7 +148,7 @@ function processExternalOrder(cfg, items, dateStr) {
   while (nextIndex < idValues.length && idValues[nextIndex]) {
     nextIndex++;
   }
-  var nextRow = idRange.getRow() + nextIndex;
+  var nextRow = headerRow + nextIndex;
 
   var ids = [], names = [], skus = [], sns = [], dates = [], prices = [], paid = [], uniqueCodes = [], locations = [], sellers = [], brands = [];
   items.forEach(function(it) {
@@ -195,10 +171,10 @@ function processExternalOrder(cfg, items, dateStr) {
   sheet.getRange(nextRow, dateCol, items.length, 1).setValues(dates);
   sheet.getRange(nextRow, priceCol, items.length, 1).setValues(prices);
   sheet.getRange(nextRow, paidCol, items.length, 1).setValues(paid);
-  if (uniqueCodeCol) sheet.getRange(nextRow, uniqueCodeCol, items.length, 1).setValues(uniqueCodes);
-  if (locationCol) sheet.getRange(nextRow, locationCol, items.length, 1).setValues(locations);
-  if (sellerCol) sheet.getRange(nextRow, sellerCol, items.length, 1).setValues(sellers);
-  if (brandCol) sheet.getRange(nextRow, brandCol, items.length, 1).setValues(brands);
+  if (uniqueCodeCol != null) sheet.getRange(nextRow, uniqueCodeCol, items.length, 1).setValues(uniqueCodes);
+  if (locationCol != null) sheet.getRange(nextRow, locationCol, items.length, 1).setValues(locations);
+  if (sellerCol != null) sheet.getRange(nextRow, sellerCol, items.length, 1).setValues(sellers);
+  if (brandCol != null) sheet.getRange(nextRow, brandCol, items.length, 1).setValues(brands);
 
   var invRange = ss.getRangeByName(cfg.inventoryRange);
   var invSheet = invRange ? invRange.getSheet() : null;


### PR DESCRIPTION
## Summary
- Simplify external order handling by using consolidated `Orders` and `StoreOrders` ranges
- Update order processing and cancellation to derive column offsets from unified ranges

## Testing
- `node --check ProductSale.js`
- `node --check CancelOrder.js`


------
https://chatgpt.com/codex/tasks/task_b_68a82edd58288332b8f38bd82f7e6e94