### PR TITLE
Remove logging and timing utilities

### DIFF
--- a/CancelOrder.js
+++ b/CancelOrder.js
@@ -1,36 +1,4 @@
-var global = this;
-
-function startTimer(name){
-  var start = Date.now();
-  return function(){
-    console.log(name + ' took ' + (Date.now() - start) + 'ms');
-  };
-}
-
-function timeStep(name, fn){
-  var end = startTimer(name);
-  try {
-    return fn();
-  } finally {
-    end();
-  }
-}
-
-function addTiming(names){
-  names.forEach(function(name){
-    var fn = global[name];
-    if (typeof fn === 'function'){
-      global[name] = function(){
-        var end = startTimer(name);
-        try {
-          return fn.apply(this, arguments);
-        } finally {
-          end();
-        }
-      };
-    }
-  });
-}
+// Removed logging and timing utilities to simplify code and avoid side effects.
 
 function getLastDataRow(range) {
   var sheet = range.getSheet();
@@ -39,9 +7,7 @@ function getLastDataRow(range) {
   var lastRow = sheet.getLastRow();
   var numRows = lastRow - range.getRow();
   if (numRows < 1) return range.getRow();
-  var values = timeStep('getLastDataRow:getValues', function(){
-    return sheet.getRange(startRow, col, numRows, 1).getValues();
-  });
+  var values = sheet.getRange(startRow, col, numRows, 1).getValues();
   for (var i = values.length - 1; i >= 0; i--) {
     var val = values[i][0];
     if (val !== '' && val !== null) {
@@ -95,35 +61,31 @@ function showCancelDialog() {
 }
 
 function cancelOrders(items) {
-  var end = startTimer('cancelOrders');
-  try {
-    if (!items || !items.length) {
-      return;
-    }
+  if (!items || !items.length) {
+    return;
+  }
     items = items.map(function(it){
       return { sn: String(it.sn), sku: it.sku != null ? String(it.sku) : '' };
     });
-    var tlSs = timeStep('open:tlSs', function(){ return SpreadsheetApp.openById('1LIR_q1xrpdzcqoBJmNXTO0UJ9dksoBjS7h3Me4PRB1s'); });
-    var tlOrders = timeStep('tlSs:getRangeByName:Orders', function(){ return tlSs.getRangeByName('Orders'); });
-    var brSs = timeStep('open:brSs', function(){ return SpreadsheetApp.openById('12-Khe_IZ9S7z_VN_LZQCHdcKEIgKDquviar8cSR_wG8'); });
-    var brOrders = timeStep('brSs:getRangeByName:StoreOrders', function(){ return brSs.getRangeByName('StoreOrders'); });
+    var tlSs = SpreadsheetApp.openById('1LIR_q1xrpdzcqoBJmNXTO0UJ9dksoBjS7h3Me4PRB1s');
+    var tlOrders = tlSs.getRangeByName('Orders');
+    var brSs = SpreadsheetApp.openById('12-Khe_IZ9S7z_VN_LZQCHdcKEIgKDquviar8cSR_wG8');
+    var brOrders = brSs.getRangeByName('StoreOrders');
     var lastRows = {};
     lastRows[tlOrders.getSheet().getSheetId()] = getLastDataRow(tlOrders.offset(0,3,tlOrders.getNumRows(),1));
     lastRows[brOrders.getSheet().getSheetId()] = getLastDataRow(brOrders.offset(0,3,brOrders.getNumRows(),1));
     var getValues = function(range, idx){
-      return timeStep('getValues:idx' + idx, function(){
-        if (!range) return [];
-        var sheet = range.getSheet();
-        var sheetId = sheet.getSheetId();
-        var lastRow = lastRows[sheetId];
-        var startRow = range.getRow() + 1;
-        var col = range.getColumn() + idx;
-        if (lastRow < startRow) return [];
-        return sheet
-          .getRange(startRow, col, lastRow - startRow + 1, 1)
-          .getValues()
-          .map(function(r){return r[0];});
-      });
+      if (!range) return [];
+      var sheet = range.getSheet();
+      var sheetId = sheet.getSheetId();
+      var lastRow = lastRows[sheetId];
+      var startRow = range.getRow() + 1;
+      var col = range.getColumn() + idx;
+      if (lastRow < startRow) return [];
+      return sheet
+        .getRange(startRow, col, lastRow - startRow + 1, 1)
+        .getValues()
+        .map(function(r){return r[0];});
     };
     var sns = getValues(tlOrders, 3).map(function(s){ return s != null ? String(s) : ''; });
     var len = sns.length;
@@ -160,96 +122,51 @@ function cancelOrders(items) {
     });
 
       function handleTL(idx){
-        var endTL = startTimer('handleTL');
-        try {
-          timeStep('handleTL:setCancel', function(){
-            try { cancelRange.getCell(idx + 2, 1).setValue(true); } catch(e) {}
-          });
-          var data = {
-            location: locations[idx],
-            name: names[idx],
-            seller: sellers[idx],
-            sku: skus[idx],
+        try { cancelRange.getCell(idx + 2, 1).setValue(true); } catch(e) {}
+        var data = {
+          location: locations[idx],
+          name: names[idx],
+          seller: sellers[idx],
+          sku: skus[idx],
           sn: sns[idx],
           unique: uniques[idx],
           brand: brands[idx]
         };
         appendToInventory(tlSs, data, false);
-      } finally {
-        endTL();
-      }
     }
 
       function handleBR(idx){
-        var endBR = startTimer('handleBR');
-        try {
-          if (idx < 0) return;
-          timeStep('handleBR:setCancel', function(){
-            try { brCancelRange.getCell(idx + 2, 1).setValue(true); } catch(e) {}
-          });
-          var data = {
-            location: brLocations[idx],
-            name: brNames[idx],
-            seller: brSellers[idx],
-            sku: brSkus[idx],
+        if (idx < 0) return;
+        try { brCancelRange.getCell(idx + 2, 1).setValue(true); } catch(e) {}
+        var data = {
+          location: brLocations[idx],
+          name: brNames[idx],
+          seller: brSellers[idx],
+          sku: brSkus[idx],
           sn: brSns[idx],
           unique: brUniques[idx],
           brand: brBrands[idx]
         };
         appendToInventory(brSs, data, true);
-      } finally {
-        endBR();
-      }
     }
 
       function appendToInventory(ss, data, isStore){
-        var endAI = startTimer('appendToInventory');
-        try {
-          var invRange = timeStep('appendToInventory:getInventoryRange', function(){
-            return ss.getRangeByName('Inventory');
-          });
-          var sheet = timeStep('appendToInventory:getSheet', function(){
-            return invRange.getSheet();
-          });
-          var row = timeStep('appendToInventory:getLastRow', function(){
-            return sheet.getLastRow() + 1;
-          });
-          var baseCol = invRange.getColumn();
-          var locationValue = data.location === 'مغازه' ? 'STORE' : data.location;
-          timeStep('appendToInventory:setLocation', function(){
-            sheet.getRange(row, baseCol + 7).setValue(locationValue);
-          });
-          timeStep('appendToInventory:setName', function(){
-            sheet.getRange(row, baseCol + 0).setValue(data.name);
-          });
-          timeStep('appendToInventory:setSeller', function(){
-            sheet.getRange(row, baseCol + 5).setValue(data.seller);
-          });
-          timeStep('appendToInventory:setSKU', function(){
-            sheet.getRange(row, baseCol + 8).setValue(data.sku);
-          });
-          timeStep('appendToInventory:setSN', function(){
-            sheet.getRange(row, baseCol + 4).setValue(data.sn);
-          });
-          timeStep('appendToInventory:setUnique', function(){
-            sheet.getRange(row, baseCol + 3).setValue(data.unique);
-          });
-          timeStep('appendToInventory:setBrand', function(){
-            sheet.getRange(row, baseCol + 1).setValue(data.brand);
-          });
-          timeStep('appendToInventory:insertLabel', function(){
-            var lblRange = ss.getRangeByName('InventoryLablePrinted');
-            var cell = sheet.getRange(row, lblRange.getColumn());
-            cell.insertCheckboxes();
-            cell.setValue(false);
-          });
-        } finally {
-          endAI();
-        }
+        var invRange = ss.getRangeByName('Inventory');
+        var sheet = invRange.getSheet();
+        var row = sheet.getLastRow() + 1;
+        var baseCol = invRange.getColumn();
+        var locationValue = data.location === 'مغازه' ? 'STORE' : data.location;
+        sheet.getRange(row, baseCol + 7).setValue(locationValue);
+        sheet.getRange(row, baseCol + 0).setValue(data.name);
+        sheet.getRange(row, baseCol + 5).setValue(data.seller);
+        sheet.getRange(row, baseCol + 8).setValue(data.sku);
+        sheet.getRange(row, baseCol + 4).setValue(data.sn);
+        sheet.getRange(row, baseCol + 3).setValue(data.unique);
+        sheet.getRange(row, baseCol + 1).setValue(data.brand);
+        var lblRange = ss.getRangeByName('InventoryLablePrinted');
+        var cell = sheet.getRange(row, lblRange.getColumn());
+        cell.insertCheckboxes();
+        cell.setValue(false);
       }
-  } finally {
-    end();
-  }
 }
 
-addTiming(['getLastDataRow', 'showCancelDialog']);

--- a/ProductSale.js
+++ b/ProductSale.js
@@ -1,27 +1,4 @@
-var global = this;
-
-function startTimer(name){
-  var start = Date.now();
-  return function(){
-    console.log(name + ' took ' + (Date.now() - start) + 'ms');
-  };
-}
-
-function addTiming(names){
-  names.forEach(function(name){
-    var fn = global[name];
-    if (typeof fn === 'function'){
-      global[name] = function(){
-        var end = startTimer(name);
-        try {
-          return fn.apply(this, arguments);
-        } finally {
-          end();
-        }
-      };
-    }
-  });
-}
+// Removed logging and timing utilities to simplify code and avoid side effects.
 
 function onOpen() {
   var ui = SpreadsheetApp.getUi();
@@ -231,14 +208,3 @@ function gregorianToJalali(gy, gm, gd) {
   return [jy, jm, jd];
 }
 
-addTiming([
-  'onOpen',
-    'showSaleDialog',
-    'getLastDataRow',
-  'getInventoryData',
-  'submitOrder',
-  'handleExternalOrders',
-  'processExternalOrder',
-  'getPersianDateTime',
-  'gregorianToJalali'
-]);

--- a/cancel.html
+++ b/cancel.html
@@ -118,26 +118,7 @@
       const MAX_DISPLAY = 200;
       const persianDigits = '۰۱۲۳۴۵۶۷۸۹';
 
-      function startTimer(name){
-        const start = performance.now();
-        return () => console.log(name + ' took ' + (performance.now() - start).toFixed(2) + 'ms');
-      }
-
-      function addTiming(names){
-        names.forEach(name => {
-          const fn = window[name];
-          if (typeof fn === 'function'){
-            window[name] = function(...args){
-              const end = startTimer(name);
-              try {
-                return fn.apply(this, args);
-              } finally {
-                end();
-              }
-            };
-          }
-        });
-      }
+      // Timing utilities removed
 
       function formatNumber(num){
         return Number(num || 0).toLocaleString('fa-IR').replace(/٬/g, ',');
@@ -275,16 +256,12 @@
       renderRows(allIndices);
 
       document.getElementById('cancelBtn').addEventListener('click', () => {
-        const end = startTimer('cancelOrders');
         const selected = Array.from(selectedMap.entries())
           .map(([sn, sku]) => ({ sn, sku }));
         google.script.run.withSuccessHandler(() => {
-          end();
           google.script.host.close();
         }).cancelOrders(selected);
       });
-
-      addTiming(['formatNumber','toEnglishDigits','toPersianDigits','formatDateStr','renderRows','toggle','updateTotal','filterOrders']);
     </script>
   </body>
 </html>

--- a/sale.html
+++ b/sale.html
@@ -344,26 +344,7 @@
       const modalProductInfo = document.getElementById('modalProductInfo');
 
       const persianDigits = '۰۱۲۳۴۵۶۷۸۹';
-      function startTimer(name){
-        const start = performance.now();
-        return () => console.log(name + ' took ' + (performance.now() - start).toFixed(2) + 'ms');
-      }
-
-      function addTiming(names){
-        names.forEach(name => {
-          const fn = window[name];
-          if (typeof fn === 'function'){
-            window[name] = function(...args){
-              const end = startTimer(name);
-              try {
-                return fn.apply(this, args);
-              } finally {
-                end();
-              }
-            };
-          }
-        });
-      }
+      // Timing utilities removed
       function formatNumber(num){
         return Number(num || 0).toLocaleString('fa-IR').replace(/٬/g, ',');
       }
@@ -677,7 +658,6 @@
       });
       const submitBtn = document.querySelector('#footer .submit');
       submitBtn.addEventListener('click', function(){
-        const end = startTimer('submitOrder');
         if(finalAmountInput.value.trim() !== '' && finalAmountReminder.style.display !== 'none'){
           const val = parseNumber(finalAmountInput.value);
           finalAmountInput.value = formatNumber(val);
@@ -703,7 +683,6 @@
           };
         });
         google.script.run.withSuccessHandler(() => {
-          end();
           resetForm();
         }).submitOrder(items);
       });
@@ -726,7 +705,6 @@
 
       setTimeout(() => snInput.focus(), 0);
 
-      addTiming(['loadInventoryData','formatNumber','parseNumber','toEnglishDigits','resetModalSearch','updateTotals','updateFinalDiscount','applyExtraDiscount','updateRowDiscount','updateRowNumbers','updateInventoryDisplay','addProduct','openSelectionModal','closeSelectionModal','resetForm']);
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- strip server-side timing helpers and console logs
- simplify CancelOrder.js and ProductSale.js to use direct spreadsheet operations
- remove browser-side timers from cancel and sale dialogs

## Testing
- `node --check CancelOrder.js`
- `node --check ProductSale.js`


------
https://chatgpt.com/codex/tasks/task_b_68a835da7c048332a3e82cfe9f6b5de2