### PR TITLE
refactor: centralize getLastDataRow

### DIFF
--- a/CancelOrder.js
+++ b/CancelOrder.js
@@ -1,22 +1,5 @@
 // Removed logging and timing utilities to simplify code and avoid side effects.
 
-function getLastDataRow(range) {
-  var sheet = range.getSheet();
-  var startRow = range.getRow() + 1;
-  var col = range.getColumn();
-  var lastRow = sheet.getLastRow();
-  var numRows = lastRow - range.getRow();
-  if (numRows < 1) return range.getRow();
-  var values = sheet.getRange(startRow, col, numRows, 1).getValues();
-  for (var i = values.length - 1; i >= 0; i--) {
-    var val = values[i][0];
-    if (val !== '' && val !== null) {
-      return startRow + i;
-    }
-  }
-  return range.getRow();
-}
-
 function showCancelDialog() {
   var ss = SpreadsheetApp.getActive();
   var snRange = ss.getRangeByName('OrderSN');
@@ -132,7 +115,7 @@ function cancelOrders(items) {
           unique: uniques[idx],
           brand: brands[idx]
         };
-        appendToInventory(tlSs, data, false);
+        appendToInventory(tlSs, data);
     }
 
       function handleBR(idx){
@@ -147,22 +130,26 @@ function cancelOrders(items) {
           unique: brUniques[idx],
           brand: brBrands[idx]
         };
-        appendToInventory(brSs, data, true);
+        appendToInventory(brSs, data);
     }
 
-      function appendToInventory(ss, data, isStore){
+      function appendToInventory(ss, data){
         var invRange = ss.getRangeByName('Inventory');
         var sheet = invRange.getSheet();
         var row = sheet.getLastRow() + 1;
         var baseCol = invRange.getColumn();
         var locationValue = data.location === 'مغازه' ? 'STORE' : data.location;
-        sheet.getRange(row, baseCol + 7).setValue(locationValue);
-        sheet.getRange(row, baseCol + 0).setValue(data.name);
-        sheet.getRange(row, baseCol + 5).setValue(data.seller);
-        sheet.getRange(row, baseCol + 8).setValue(data.sku);
-        sheet.getRange(row, baseCol + 4).setValue(data.sn);
-        sheet.getRange(row, baseCol + 3).setValue(data.unique);
-        sheet.getRange(row, baseCol + 1).setValue(data.brand);
+        var rowValues = [];
+        rowValues[0] = data.name;
+        rowValues[1] = data.brand;
+        rowValues[2] = '';
+        rowValues[3] = data.unique;
+        rowValues[4] = data.sn;
+        rowValues[5] = data.seller;
+        rowValues[6] = '';
+        rowValues[7] = locationValue;
+        rowValues[8] = data.sku;
+        sheet.getRange(row, baseCol, 1, 9).setValues([rowValues]);
         var lblRange = ss.getRangeByName('InventoryLablePrinted');
         var cell = sheet.getRange(row, lblRange.getColumn());
         cell.insertCheckboxes();

--- a/ProductSale.js
+++ b/ProductSale.js
@@ -17,39 +17,19 @@ function showSaleDialog() {
     .setHeight(800);
   SpreadsheetApp.getUi().showModalDialog(html, 'فروش محصول');
 }
-
-  function getLastDataRow(range) {
-    var sheet = range.getSheet();
-    var startRow = range.getRow() + 1;
-    var col = range.getColumn();
-    var lastRow = sheet.getLastRow();
-  var numRows = lastRow - range.getRow();
-  if (numRows < 1) return range.getRow();
-  var values = sheet.getRange(startRow, col, numRows, 1).getValues();
-  for (var i = values.length - 1; i >= 0; i--) {
-    var val = values[i][0];
-    if (val !== '' && val !== null) {
-      return startRow + i;
-    }
-  }
-  return range.getRow();
-}
+var EMPTY_INVENTORY_DATA = {names:[], skus:[], sns:[], persianSNS:[], locations:[], prices:[], uniqueCodes:[], brands:[], sellers:[]};
 
 function getInventoryData() {
-  var ss = SpreadsheetApp.getActive();
-  var invRange = ss.getRangeByName('Inventory');
-  if (!invRange) {
-    return {names:[], skus:[], sns:[], persianSNS:[], locations:[], prices:[], uniqueCodes:[], brands:[], sellers:[]};
-  }
+  var invRange = SpreadsheetApp.getActive().getRangeByName('Inventory');
+  if (!invRange) return EMPTY_INVENTORY_DATA;
   var sheet = invRange.getSheet();
   var lastRow = getLastDataRow(invRange);
   var numRows = lastRow - invRange.getRow();
-  if (numRows < 1) {
-    return {names:[], skus:[], sns:[], persianSNS:[], locations:[], prices:[], uniqueCodes:[], brands:[], sellers:[]};
-  }
+  if (numRows < 1) return EMPTY_INVENTORY_DATA;
   var values = sheet.getRange(invRange.getRow() + 1, invRange.getColumn(), numRows, invRange.getNumColumns()).getValues();
   var names = [], brands = [], uniqueCodes = [], sns = [], sellers = [], prices = [], locations = [], skus = [], persianSns = [];
-  values.forEach(function(r){
+  for (var i = 0; i < values.length; i++) {
+    var r = values[i];
     names.push(r[0]);
     brands.push(r[1]);
     uniqueCodes.push(r[3]);
@@ -59,9 +39,9 @@ function getInventoryData() {
     locations.push(r[7]);
     skus.push(r[8]);
     persianSns.push(r[9]);
-  });
-  return {names:names, skus:skus, sns:sns, persianSNS:persianSns, locations:locations, prices:prices, uniqueCodes:uniqueCodes, brands:brands, sellers:sellers};
   }
+  return {names:names, skus:skus, sns:sns, persianSNS:persianSns, locations:locations, prices:prices, uniqueCodes:uniqueCodes, brands:brands, sellers:sellers};
+}
 
 function submitOrder(items) {
   if (!items || !items.length) {

--- a/Utils.js
+++ b/Utils.js
@@ -1,0 +1,16 @@
+function getLastDataRow(range) {
+  var sheet = range.getSheet();
+  var startRow = range.getRow() + 1;
+  var col = range.getColumn();
+  var lastRow = sheet.getLastRow();
+  var numRows = lastRow - range.getRow();
+  if (numRows < 1) return range.getRow();
+  var values = sheet.getRange(startRow, col, numRows, 1).getValues();
+  for (var i = values.length - 1; i >= 0; i--) {
+    var val = values[i][0];
+    if (val !== '' && val !== null) {
+      return startRow + i;
+    }
+  }
+  return range.getRow();
+}


### PR DESCRIPTION
## Summary
- Move duplicated `getLastDataRow` into new `Utils.js`
- Streamline inventory retrieval with reusable constant and loop
- Batch inventory updates on order cancellation for efficiency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a838581a28833286c2493613892c65