### PR TITLE
Set cancel status column to true

### DIFF
--- a/CancelOrder.js
+++ b/CancelOrder.js
@@ -112,7 +112,9 @@ function cancelOrders(items) {
     });
 
       function handleTL(idx){
-        try { cancelRange.getCell(idx + 2, 1).setValue(true); } catch(e) {}
+        try {
+          cancelRange.offset(1, 0, cancelRange.getNumRows() - 1).setValue(true);
+        } catch(e) {}
         var data = {
           location: locations[idx],
           name: names[idx],
@@ -127,7 +129,9 @@ function cancelOrders(items) {
 
       function handleBR(idx){
         if (idx < 0) return;
-        try { brCancelRange.getCell(idx + 2, 1).setValue(true); } catch(e) {}
+        try {
+          brCancelRange.offset(1, 0, brCancelRange.getNumRows() - 1).setValue(true);
+        } catch(e) {}
         var data = {
           location: brLocations[idx],
           name: brNames[idx],


### PR DESCRIPTION
## Summary
- ensure ToylandOrders and BuyruzPosOrders status columns are fully marked TRUE when cancelling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a8a6371f3083328f2b2882c5e31583