### PR TITLE
Fix order cancellation to update specific rows

### DIFF
--- a/CancelOrder.js
+++ b/CancelOrder.js
@@ -112,9 +112,7 @@ function cancelOrders(items) {
     });
 
       function handleTL(idx){
-        try {
-          cancelRange.offset(1, 0, cancelRange.getNumRows() - 1).setValue(true);
-        } catch(e) {}
+        try { cancelRange.getCell(idx + 2, 1).setValue(true); } catch(e) {}
         var data = {
           location: locations[idx],
           name: names[idx],
@@ -129,9 +127,7 @@ function cancelOrders(items) {
 
       function handleBR(idx){
         if (idx < 0) return;
-        try {
-          brCancelRange.offset(1, 0, brCancelRange.getNumRows() - 1).setValue(true);
-        } catch(e) {}
+        try { brCancelRange.getCell(idx + 2, 1).setValue(true); } catch(e) {}
         var data = {
           location: brLocations[idx],
           name: brNames[idx],


### PR DESCRIPTION
## Summary
- Ensure `cancelOrders` marks the cancellation flag only for the targeted order in both Toyland and Buyruz sheets.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a8aa2da2608332a73d3541d1f3f31f