### PR TITLE
Fix SKU transfer for order cancellation

### DIFF
--- a/CancelOrder.js
+++ b/CancelOrder.js
@@ -97,7 +97,7 @@ function processCancelGroup(ss, items, ordersRangeName, inventoryRangeName) {
       cancelValues[idx][0] = true;
       var row = data[idx];
       var locationValue = row[7] === 'مغازه' ? 'STORE' : row[7];
-      invRows.push([row[1], row[9], '', row[10], row[3], row[8], '', locationValue, row[2]]);
+      invRows.push([row[1], row[9], row[2], row[10], row[3], row[8], '', locationValue, '']);
     }
   });
   sheet.getRange(startRow, cancelCol, dataRows, 1).setValues(cancelValues);


### PR DESCRIPTION
## Summary
- Ensure canceled orders copy SKU from orders sheet column 3 into inventory sheet column 3
- Preserve checkbox column by leaving final inventory column empty

## Testing
- `node --check CancelOrder.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a986ed63b8833292bed95dec8e3086