### PR TITLE
Limit data operations to non-header rows

### DIFF
--- a/CancelOrder.js
+++ b/CancelOrder.js
@@ -6,7 +6,7 @@ function showCancelDialog() {
   if (!posRange) return;
   var sheet = posRange.getSheet();
   var lastRow = getLastDataRow(posRange.offset(0, 3));
-  var startRow = posRange.getRow() + 1;
+  var startRow = getDataStartRow(posRange);
   if (lastRow < startRow) return;
   var numRows = lastRow - startRow + 1;
   var values = sheet
@@ -79,7 +79,7 @@ function processCancelGroup(ss, items, ordersRangeName, inventoryRangeName, tran
   if (!ordersRange) return;
   var sheet = ordersRange.getSheet();
   var lastRow = getLastDataRow(ordersRange.offset(0,3,ordersRange.getNumRows(),1));
-  var startRow = ordersRange.getRow() + 1;
+  var startRow = getDataStartRow(ordersRange);
   if (lastRow < startRow) return;
   var dataRows = lastRow - startRow + 1;
   var numCols = ordersRange.getNumColumns();
@@ -106,7 +106,7 @@ function processCancelGroup(ss, items, ordersRangeName, inventoryRangeName, tran
     var invRange = ss.getRangeByName(inventoryRangeName);
     var invSheet = invRange.getSheet();
     var baseCol = invRange.getColumn();
-    var start = invSheet.getLastRow() + 1;
+    var start = getLastDataRow(invRange) + 1;
     invSheet.getRange(start, baseCol, invRows.length, invRange.getNumColumns()).setValues(invRows);
     var labelRange = invSheet.getRange(start, baseCol + 8, invRows.length, 1);
     labelRange.insertCheckboxes();

--- a/ProductSale.js
+++ b/ProductSale.js
@@ -23,10 +23,11 @@ function getInventoryData() {
   var empty = {names:[], skus:[], sns:[], persianSNS:[], locations:[], prices:[], uniqueCodes:[], brands:[], sellers:[]};
   if (!invRange) return empty;
   var sheet = invRange.getSheet();
+  var startRow = getDataStartRow(invRange);
   var lastRow = getLastDataRow(invRange);
-  var numRows = lastRow - invRange.getRow();
+  var numRows = lastRow - startRow + 1;
   if (numRows < 1) return empty;
-  var values = sheet.getRange(invRange.getRow() + 1, invRange.getColumn(), numRows, invRange.getNumColumns()).getValues();
+  var values = sheet.getRange(startRow, invRange.getColumn(), numRows, invRange.getNumColumns()).getValues();
   var names = [], brands = [], uniqueCodes = [], sns = [], sellers = [], prices = [], locations = [], skus = [], persianSns = [];
   for (var i = 0; i < values.length; i++) {
     var r = values[i];
@@ -91,9 +92,9 @@ function processExternalOrder(cfg, items, dateStr, orderId) {
   var brandCol = col(9);
   var uniqueCodeCol = col(10);
 
-  var headerRow = ordersRange.getRow();
-  var dataStart = headerRow + 1;
-  var dataRows = sheet.getLastRow() - headerRow;
+  var dataStart = getDataStartRow(ordersRange);
+  var lastOrderRow = getLastDataRow(ordersRange);
+  var dataRows = lastOrderRow >= dataStart ? lastOrderRow - dataStart + 1 : 0;
   var idValues = dataRows > 0 ? sheet.getRange(dataStart, idCol, dataRows, 1).getValues().map(function(r){ return r[0]; }) : [];
   var nextIndex = 0;
   while (nextIndex < idValues.length && idValues[nextIndex]) {
@@ -121,9 +122,10 @@ function processExternalOrder(cfg, items, dateStr, orderId) {
   var invRange = ss.getRangeByName(cfg.inventoryRange);
   if (invRange) {
     var invSheet = invRange.getSheet();
-    var invDataStart = invRange.getRow() + 1;
+    var invDataStart = getDataStartRow(invRange);
     var numInvCols = invRange.getNumColumns();
-    var invDataRows = invSheet.getLastRow() - invRange.getRow();
+    var invLastRow = getLastDataRow(invRange);
+    var invDataRows = invLastRow >= invDataStart ? invLastRow - invDataStart + 1 : 0;
     var invValues = invDataRows > 0 ? invSheet.getRange(invDataStart, invRange.getColumn(), invDataRows, numInvCols).getValues() : [];
     var removeSet = items.map(function(it){ return String(it.serial).trim(); });
     var filtered = invValues.filter(function(r){ return removeSet.indexOf(String(r[4]).trim()) === -1; });
@@ -145,11 +147,12 @@ function getNextOrderId() {
   var posOrdersRange = ss.getRangeByName('PosOrders');
   if (!posOrdersRange) return 1;
   var sheet = posOrdersRange.getSheet();
-  var headerRow = posOrdersRange.getRow();
   var idCol = posOrdersRange.getColumn();
-  var dataRows = sheet.getLastRow() - headerRow;
+  var dataStart = getDataStartRow(posOrdersRange);
+  var lastRow = getLastDataRow(posOrdersRange);
+  var dataRows = lastRow >= dataStart ? lastRow - dataStart + 1 : 0;
   if (dataRows < 1) return 1;
-  var values = sheet.getRange(headerRow + 1, idCol, dataRows, 1).getValues();
+  var values = sheet.getRange(dataStart, idCol, dataRows, 1).getValues();
   var lastId = 0;
   values.forEach(function(r) {
     var num = parseInt(String(r[0]).replace(/\D/g, ''), 10);

--- a/Utils.js
+++ b/Utils.js
@@ -1,18 +1,26 @@
+function getDataStartRow(range) {
+  var sheet = range.getSheet();
+  var frozenRows = sheet.getFrozenRows();
+  return range.getRow() <= frozenRows ? frozenRows + 1 : range.getRow();
+}
+
 function getLastDataRow(range) {
   var sheet = range.getSheet();
-  var startRow = range.getRow() + 1;
-  var col = range.getColumn();
-  var lastRow = sheet.getLastRow();
-  var numRows = lastRow - range.getRow();
-  if (numRows < 1) return range.getRow();
-  var values = sheet.getRange(startRow, col, numRows, 1).getValues();
+  var startRow = getDataStartRow(range);
+  var startCol = range.getColumn();
+  var numRows = range.getNumRows() - (startRow - range.getRow());
+  var numCols = range.getNumColumns();
+  if (numRows < 1) return startRow - 1;
+  var values = sheet.getRange(startRow, startCol, numRows, numCols).getValues();
   for (var i = values.length - 1; i >= 0; i--) {
-    var val = values[i][0];
-    if (val !== '' && val !== null) {
-      return startRow + i;
+    for (var j = 0; j < numCols; j++) {
+      var val = values[i][j];
+      if (val !== '' && val !== null) {
+        return startRow + i;
+      }
     }
   }
-  return range.getRow();
+  return startRow - 1;
 }
 
 function getPersianDateTime() {


### PR DESCRIPTION
## Summary
- Add utility to detect first data row and update last-row lookup to skip frozen headers and trailing blanks
- Restrict inventory and order read/write logic to populated rows only
- Append cancelled items to inventories after existing data

## Testing
- `node --check Utils.js && echo 'Utils OK'`
- `node --check ProductSale.js && echo 'ProductSale OK'`
- `node --check CancelOrder.js && echo 'CancelOrder OK'`
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aac726923483329da69a3d2dc55326