### PR TITLE
Prevent duplicate serial orders and add error handling

### DIFF
--- a/ProductSale.js
+++ b/ProductSale.js
@@ -48,9 +48,40 @@ function submitOrder(items) {
   if (!items || !items.length) {
     return;
   }
+  ensureSerialAvailability(items);
   var dateStr = getPersianDateTime();
   var orderId = getNextOrderId();
   handleExternalOrders(dateStr, items, orderId);
+}
+
+function ensureSerialAvailability(items) {
+  var ss = SpreadsheetApp.getActive();
+  var posOrdersRange = ss.getRangeByName('PosOrders');
+  if (!posOrdersRange) return;
+  var sheet = posOrdersRange.getSheet();
+  var serialCol = posOrdersRange.getColumn() + 3;
+  var dataStart = getDataStartRow(posOrdersRange);
+  var lastRow = getLastDataRow(posOrdersRange);
+  var dataRows = lastRow >= dataStart ? lastRow - dataStart + 1 : 0;
+  var existing = {};
+  if (dataRows > 0) {
+    var vals = sheet.getRange(dataStart, serialCol, dataRows, 1).getValues();
+    for (var i = 0; i < vals.length; i++) {
+      var s = String(vals[i][0]).trim();
+      if (s) existing[s] = true;
+    }
+  }
+  var seen = {};
+  var duplicates = [];
+  items.forEach(function(it) {
+    var s = String(it.serial).trim();
+    if (!s) return;
+    if (existing[s] || seen[s]) duplicates.push(s);
+    seen[s] = true;
+  });
+  if (duplicates.length) {
+    throw new Error('سریال ' + duplicates.join(', ') + ' قبلا به فروش رفته و موجود نیست');
+  }
 }
 
 function handleExternalOrders(dateStr, items, orderId) {

--- a/sale.html
+++ b/sale.html
@@ -682,9 +682,14 @@
             brand: row.dataset.brand || ''
           };
         });
-        google.script.run.withSuccessHandler(() => {
-          resetForm();
-        }).submitOrder(items);
+        google.script.run
+          .withSuccessHandler(() => {
+            resetForm();
+          })
+          .withFailureHandler(err => {
+            alert(err.message);
+          })
+          .submitOrder(items);
       });
 
       function resetForm(){


### PR DESCRIPTION
## Summary
- Validate serial numbers before submitting orders to avoid duplicates
- Alert users when serials are already sold

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aace667f8c8332b1c610d81dbed6e3